### PR TITLE
new diagram, entropy source footnote, FIPS 140-3 IG link

### DIFF
--- a/doc/diagrams/esstate_tikz.tex
+++ b/doc/diagrams/esstate_tikz.tex
@@ -1,9 +1,13 @@
-%	esstate_tikz.tex
-%	2020-06-26	Markku-Juhani O. Saarinen <mjos@pqshield.com>
+%   esstate.tikz
+%   2020-06-26  Markku-Juhani O. Saarinen <mjos@pqshield.com>
 
 \begin{tikzpicture}[>=latex,scale=1.2]
+\tikzset{every state/.append style={rectangle, thick, rounded corners}};
 
-\tikzset{every state/.append style={rectangle, rounded corners}}
+%   NOISE_TEST = 0
+
+\draw[draw=none,fill=gray!10] (-1.5,0) rectangle ++(3,0.5) node[pos=0.5]
+    {\small\tt NOISE\_TEST = 0};
 
 \node[align=center] (reset) at (0,-0.5) {reset};
 \node[state,fill=cyan!10] (bist) at (0,-1.5) {BIST};
@@ -19,30 +23,71 @@
 \node[align=center] (dead2) at (0,-5.5) {\em stays dead!};
 
 \draw[->] (reset) to (bist);
-\draw[->] (bist) to (wait); 
-\draw[->] (bist) to (es16); 
+\draw[->] (bist) to (wait);
+\draw[->] (bist) to (es16);
 
-\draw[->, bend left] (wait) to (es16); 
+\draw[->, bend left] (wait) to (es16);
 \draw[->, bend left] (es16) to (wait);
 
 \draw[color=red,dashed,->] (bist) .. controls (-2.5,-2.5) and (-2.5,-3.5) .. (dead);
 
-\draw[color=red,dashed,->] (wait) to (dead); 
+\draw[color=red,dashed,->] (wait) to (dead);
 \draw[color=red,dashed,->] (es16) to (dead);
 
 \draw[->] (dead) .. controls ++(0.15,-0.85) and ++(-0.15,-0.85) .. (dead);
 
-\node[color=red,align=center] at (-1.5,-4.5) {{\it fatal}\\{\it error}}; 
+\node[color=red,align=center] at (-1.5,-4.5) {{\it fatal}\\{\it error}};
 
-\draw[color=cyan,densely dotted,->] (bist) .. controls ++(0.85,-0.15) 
-	and ++(0.85,+0.15) .. (bist);
+\draw[color=cyan,densely dotted,->] (bist) .. controls ++(-0.85,-0.15)
+    and ++(-0.85,0.15) .. (bist);
 
-\draw[color=cyan,densely dotted,->] (wait) .. controls (-1.0,-2.7) 
-	and (-1.0,-2.2) .. (bist);
+\draw[color=cyan,densely dotted,->] (wait) .. controls (-1.0,-2.7)
+    and (-1.0,-2.2) .. (bist);
 
-\draw[color=cyan,densely dotted,->] (es16) .. controls (1.0,-2.7) 
-	and (1.0,-2.2) .. (bist);
+\draw[color=cyan,densely dotted,->] (es16) .. controls (1.0,-2.7)
+    and (1.0,-2.2) .. (bist);
 
 \node[color=cyan,align=center] at (1.5,-2.0) {{\it non-fatal}\\{\it alarm}};
 
+%   NOISE_TEST = 1
+
+\draw[dashed,gray] (2.5,-1) -- (2.5,-5);
+
+\draw[draw=none,fill=gray!10] (3.5,0) rectangle ++(3,0.5) node[pos=0.5]
+    {\small\tt NOISE\_TEST = 1};
+
+\node[state,fill=cyan!10] (bist2) at (5,-1.5) {BIST};
+
+\draw[color=cyan,densely dotted,->] (bist2) .. controls ++(0.85,0.15)
+    and ++(0.85,-0.15) .. (bist2);
+
+\node[state,fill=red!20] (dead2) at (5,-4.5) {DEAD};
+
+\draw[->] (dead2) .. controls ++(0.15,-0.85) and ++(-0.15,-0.85) .. (dead2);
+
+\draw[color=red,dashed,->] (bist2) .. controls (7.5,-2.5) and (7.5,-3.5) .. (dead2);
+
+
+\draw[gray,->] (bist2) .. controls (3,-0.7) and (2,-0.7) .. (bist)
+    node[pos=.5,above] {\small test mode disabled};
+
+\draw[gray,->] (dead2) .. controls (3,-5.2) and (2,-5.2) .. (dead)
+    node[pos=.5,below] {\small test mode disabled};
+
+\node[right,color=gray] (enable) at (2.5,-1.3) {\small\underline{enabled:}};
+\node[right,color=gray] (bistn) at (2.5,-1.7) {\small BIST};
+\node[right,color=gray] (waitn) at (2.5,-2.1) {\small WAIT};
+\node[right,color=gray] (es16n) at (2.5,-2.5) {\small ES16};
+
+\node[right,color=gray] (deadn) at (2.5,-4.5) {\small DEAD};
+
+\draw[gray,->] (bistn.e) -- (bist2);
+\draw[gray,->] (waitn.e) -- (bist2);
+\draw[gray,->] (es16n.e) -- (bist2);
+\draw[gray,->] (deadn.e) -- (dead2);
+
+\node[state,dashed,align=center] (getnoise) at (5,-3)
+    { {\small GetNoise active:}\\{\small {\bf no} PollEntropy}};
+
 \end{tikzpicture}
+

--- a/doc/riscv-crypto-spec.bib
+++ b/doc/riscv-crypto-spec.bib
@@ -829,11 +829,11 @@
 
 @Misc{		  NICC20,
   author	= {{NIST} and {CCCS}},
-  title		= {Implementation Guidance for {FIPS} 140-2 and the
+  title		= {Implementation Guidance for {FIPS} 140-3 and the
 		  Cryptographic Module Validation Program},
   howpublished	= {CMVP Update},
-  month		= {August},
-  url		= {https://csrc.nist.gov/CSRC/media/Projects/cryptographic-module-validation-program/documents/fips140-2/FIPS1402IG.pdf},
+  month		= {September},
+  url		= {https://csrc.nist.gov/CSRC/media/Projects/cryptographic-module-validation-program/documents/fips%20140-3/FIPS%20140-3%20IG.pdf},
   year		= {2020}
 }
 

--- a/doc/tex/appx-entropy.tex
+++ b/doc/tex/appx-entropy.tex
@@ -148,7 +148,7 @@
     size of the CBC-MAC conditioner specified in \cite{TuBaKe+18} and also
     the smallest key size we expect to see in applications.
 
-    \paragraph{(Sect. \ref{sec:req-es}) \S E2, I.I.D. Requirement:}
+    \paragraph{(Sect. \ref{sec:req-es}) \S E2, IID Requirement:}
     IID is an optional requirement in SP 800-90B \cite{TuBaKe+18} but it
     is needed to prevent information leakage between different entities that
     possibly share the same entropy source. It also significantly

--- a/doc/tex/sec-entropy-source.tex
+++ b/doc/tex/sec-entropy-source.tex
@@ -217,8 +217,8 @@ RV32, RV64
         \cite[Section D.K.]{NICC20} are being revised at the time of writing.
         The type of appropriate post-processing for IID track depends on
         the physical noise source. Some simple post-processing methods are
-        currently considered to be part of sampling (``digitization'') step
-        of the process. Vetted or non-vetted conditioning may also be
+        currently considered to be part of the sampling (``digitization'')\
+        step of the process. Vetted or non-vetted conditioning may also be
         required in hardware, forming a hardware-software conditioning chain.}
 
     \begin{itemize}

--- a/doc/tex/sec-entropy-source.tex
+++ b/doc/tex/sec-entropy-source.tex
@@ -118,7 +118,9 @@ RV32, RV64
         (no data) and ES16, which means that 16 bits of randomness (seed)
         has been polled. BIST (Built-in Self-Test) only occurs after reset
         or to signal a non-fatal self-test alarm (if reached after WAIT or
-        ES16). DEAD is an unrecoverable error state.}
+        ES16). DEAD is an unrecoverable error state.
+        In test mode (when GetNoise is active) WAIT and ES16 states are
+        unavailable in PollEntropy.}
 %   \Description{State diagram of the Entropy Source.}
     \label{fig:esstate_tikz}
 \end{figure}
@@ -206,11 +208,18 @@ RV32, RV64
     classical or quantum adversary
     \cite[Section 4.A.4 Security Strength Categories]{NI16}.
 
-    \subsubsection{FIPS 140-3 / SP 800-90 I.I.D. Track}
+    \subsubsection{FIPS 140-3 / SP 800-90 IID Track}
 
-    For FIPS 140-3 certification, vendors should design their entropy sources
-    and hardware conditioning components so that they can be submitted to
-    the  ``I.I.D. track''.
+    For FIPS 140-3 certification, vendors should design their physical entropy
+    sources so that they can be submitted to the  ``IID track''. This usually
+    requires post-processing of noise in hardware.\footnote{NIST SP 800-90B
+        \cite{TuBaKe+18} and its  FIPS 140-3 Implementation Guidance
+        \cite[Section D.K.]{NICC20} are being revised at the time of writing.
+        The type of appropriate post-processing for IID track depends on
+        the physical noise source. Some simple post-processing methods are
+        currently considered to be part of sampling (``digitization'') step of
+        of the process by the implementation guidance. Hardware conditioning
+        may also be required, forming a hardware-software conditioning chain.}
 
     \begin{itemize}
 
@@ -229,7 +238,7 @@ RV32, RV64
     prohibited from using more than twice the number of seed bits relative
     to the desired resulting entropy.
 
-    \item[\S E2]    {\bf SP 800-90B I.I.D.}
+    \item[\S E2]    {\bf SP 800-90B IID}
     The output must be close to \emph{Independent and Identically Distributed}
     (IID), meaning that the output distribution does not deteriorate over
     time and that output words convey little information about each other.
@@ -238,7 +247,7 @@ RV32, RV64
     and the IID tests in Section 5 of NIST SP 800-90B \cite{TuBaKe+18} are
     consistently passed.
 
-    \end{itemize}
+    \end{itemize}g
 
     Note that both requirements must be satisfied (\S E1 may appear looser
     than \S E2). FIPS 140-3 certification of course imposes many additional
@@ -286,7 +295,7 @@ RV32, RV64
     \verb|seed| bits may be designated as internal random bits for \S P7,
     we recommend that all 16 ES bits meet this requirement.
 
-    Note that in Common Criteria validation the SP 800-90B I.I.D. requirement
+    Note that in Common Criteria validation the SP 800-90B IID requirement
     of \S E2 is not stated. However, it may also be satisfied -- and the
     H=0.997 level of \S P7 / PTG.2.7 leaves relatively little ``room'' for an
     entropy defect (mutual entropy).

--- a/doc/tex/sec-entropy-source.tex
+++ b/doc/tex/sec-entropy-source.tex
@@ -217,9 +217,9 @@ RV32, RV64
         \cite[Section D.K.]{NICC20} are being revised at the time of writing.
         The type of appropriate post-processing for IID track depends on
         the physical noise source. Some simple post-processing methods are
-        currently considered to be part of sampling (``digitization'') step of
-        of the process by the implementation guidance. Hardware conditioning
-        may also be required, forming a hardware-software conditioning chain.}
+        currently considered to be part of sampling (``digitization'') step
+        of the process. Vetted or non-vetted conditioning may also be
+        required in hardware, forming a hardware-software conditioning chain.}
 
     \begin{itemize}
 


### PR DESCRIPTION
Updates:
- New diagram as requested by Richard, taking NOISE_TEST into account
- Switched I.I.D. to IID as suggested by some reviewers
- Footnote 9 on page 23 about how to meet IID and that simple post-processing may be "digitization"