### PR TITLE
remove the param redundancy in api-aes.h

### DIFF
--- a/benchmarks/aes/api_aes.h
+++ b/benchmarks/aes/api_aes.h
@@ -117,7 +117,6 @@ void    aes_256_dec_key_schedule (
 @param [out] ct - Output cipher text
 @param [in]  pt - Input plaintext
 @param [in]  rk - The expanded key schedule
-@param [in]  nr - Number of encryption rounds to perform.
 */
 void    aes_128_ecb_encrypt (
     uint8_t     ct [AES_BLOCK_BYTES],
@@ -130,7 +129,6 @@ void    aes_128_ecb_encrypt (
 @param [out] ct - Output cipher text
 @param [in]  pt - Input plaintext
 @param [in]  rk - The expanded key schedule
-@param [in]  nr - Number of encryption rounds to perform.
 */
 void    aes_192_ecb_encrypt (
     uint8_t     ct [AES_BLOCK_BYTES],
@@ -143,7 +141,6 @@ void    aes_192_ecb_encrypt (
 @param [out] ct - Output cipher text
 @param [in]  pt - Input plaintext
 @param [in]  rk - The expanded key schedule
-@param [in]  nr - Number of encryption rounds to perform.
 */
 void    aes_256_ecb_encrypt (
     uint8_t     ct [AES_BLOCK_BYTES],
@@ -156,7 +153,6 @@ void    aes_256_ecb_encrypt (
 @param [out] pt - Output plaintext
 @param [in]  ct - Input cipher text
 @param [in]  rk - The expanded key schedule
-@param [in]  nr - Number of decryption rounds to perform.
 */
 void    aes_128_ecb_decrypt (
     uint8_t     pt [AES_BLOCK_BYTES],
@@ -169,7 +165,6 @@ void    aes_128_ecb_decrypt (
 @param [out] pt - Output plaintext
 @param [in]  ct - Input cipher text
 @param [in]  rk - The expanded key schedule
-@param [in]  nr - Number of decryption rounds to perform.
 */
 void    aes_192_ecb_decrypt (
     uint8_t     pt [AES_BLOCK_BYTES],
@@ -183,7 +178,6 @@ void    aes_192_ecb_decrypt (
 @param [out] pt - Output plaintext
 @param [in]  ct - Input cipher text
 @param [in]  rk - The expanded key schedule
-@param [in]  nr - Number of decryption rounds to perform.
 */
 void    aes_256_ecb_decrypt (
     uint8_t     pt [AES_BLOCK_BYTES],


### PR DESCRIPTION
when I make the doxygen file of benchmarks , there's an error, so I came to  find that there are some redundancy in the api-aes.h. I fix it. But I wonder that should we add a definition of aes_ecb_decrypt in the api-aes.h to let the user know more clearly about how the parameter - number of round  affect the code.