### PR TITLE
clarification on entropy source accesss in vs/vu modes

### DIFF
--- a/doc/scalar/riscv-crypto-scalar-entropy-source.adoc
+++ b/doc/scalar/riscv-crypto-scalar-entropy-source.adoc
@@ -246,16 +246,18 @@ The `seed` CSR is by default only available in M mode, but can be made
 available to other modes via the `mseccfg.sseed` and `mseccfg.useed`
 access control bits. `sseed` is bit `9` of and `useed` is
 bit `8` of the `mseccfg` CSR.
-Without the corresponding access control bit set to 1, an attempted
-read/write access to `seed` from U, S, or HS modes will raise an
-illegal instruction Exception. 
+Without the corresponding access control bit set to 1, any attempted
+access to `seed` from U, S, or HS modes will raise an illegal instruction
+exception. 
 
-Attempted access to `seed` from virtual modes VS and VU always raises an
-exception; a read-only instruction causes an illegal instruction Exception,
-while a read-write instruction (that can potentially be emulated) causes
-a virtual instruction Exception. Note that HS, VS, and VU modes are
-present in systems with Hypervisor (H) extension implemented. If desired, 
-a hypervisor can emulate accesses to the seed CSR from a virtual machine.
+VS and VU modes are present in systems with Hypervisor (H) extension
+implemented. If desired, a hypervisor can emulate accesses to the seed CSR
+from a virtual machine. Attempted access to `seed` from virtual modes
+VS and VU always raises an exception; a read-only instruction causes an
+illegal instruction exception, while a read-write instruction (that can
+potentially be emulated) causes a virtual instruction exception only if
+`mseccfg.sseed=1`. Note that `mseccfg.useed` has no effect on the exception
+type for either VS or VU modes. 
 
 .Entropy Source Access Control.
 
@@ -268,37 +270,42 @@ a hypervisor can emulate accesses to the seed CSR from a virtual machine.
 | `*`
 | The `seed` CSR is always available in machine mode as normal (with a
 CSR read-write instruction.) Attempted read without a write raises an
-illegal instruction Exception regardless of mode and access control bits.
+illegal instruction exception regardless of mode and access control bits.
+
+| U
+| `*`
+| `0`
+| Any `seed` CSR access raises an illegal instruction exception.
+
+| U
+| `*`
+| `1`
+| The `seed` CSR is accessible as normal. No exception is raised for read-write.
+
+| S/HS
+| `0`
+| `*`
+| Any `seed` CSR access raises an illegal instruction exception.
+
+
+| S/HS
+| `1`
+| `*`
+| The `seed` CSR is accessible as normal. No exception is raised for read-write.
 
 | VS/VU
-| `*`
-| `*`
-| The `seed` CSR is never directly available from virtual (VS or VU)
-modes. A read-write instruction causes a virtual instruction Exception
-(while a read-only instruction always causes an illegal instruction Exception.)
-
-| S/HS
 | `0`
 | `*`
-| Any `seed` CSR access raises an illegal instruction Exception.
+| Any `seed` CSR access raises an illegal instruction exception.
 
-| S/HS
+| VS/VU
 | `1`
 | `*`
-| The `seed` CSR is accessible as normal. No exception is raised for read-write.
-
-| U
-| `*`
-| `0`
-| Any `seed` CSR access raises an illegal instruction Exception.
-
-| U
-| `*`
-| `1`
-| The `seed` CSR is accessible as normal. No exception is raised for read-write.
-
+| A read-write `seed` access raises a virtual instruction exception,
+while other access conditions raise an illegal instruction exception.
 
 |=======================================================================
+
 
 Systems should implement carefully considered access control policies from
 lower privilege modes to physical entropy sources. The system can trap


### PR DESCRIPTION
Further changes the behavior of VS/VU modes so that a virtual instruction exception is raised only for read-write accesses when mseccfg.sseed=1. Thanks to John Hauser for the clarification. Hopefully closes https://github.com/riscv/riscv-crypto/issues/139