### PR TITLE
typo: the the

### DIFF
--- a/doc/scalar/insns/sha512sum0r.adoc
+++ b/doc/scalar/insns/sha512sum0r.adoc
@@ -2,7 +2,7 @@
 === sha512sum0r
 
 Synopsis::
-Implements the the Sum0 transformation, as
+Implements the Sum0 transformation, as
 used in the SHA2-512 hash function cite:[nist:fips:180:4] (Section 4.1.3).
 
 Mnemonic::

--- a/doc/scalar/insns/sha512sum1r.adoc
+++ b/doc/scalar/insns/sha512sum1r.adoc
@@ -2,7 +2,7 @@
 === sha512sum1r
 
 Synopsis::
-Implements the the Sum1 transformation, as
+Implements the Sum1 transformation, as
 used in the SHA2-512 hash function cite:[nist:fips:180:4] (Section 4.1.3).
 
 Mnemonic::


### PR DESCRIPTION
Typographic error "the the" -> "the" in two instruction summaries.