### PR TITLE
Fix a couple wavedrom errors

### DIFF
--- a/doc/vector/insns/vaesd256.adoc
+++ b/doc/vector/insns/vaesd256.adoc
@@ -10,6 +10,7 @@ vaesd256.v vd, vs2, vs1
 Encoding (Vector)::
 [wavedrom, , svg]
 ....
+{reg:[
 {bits: 7, name: 'OPMVV'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'func3'},
@@ -17,6 +18,7 @@ Encoding (Vector)::
 {bits: 5, name: 'vs2'},
 {bits: 1, name: 'vm=0'},
 {bits: 6, name: 'funct6'},
+]}
 ....
 
 Arguments::

--- a/doc/vector/insns/vror.adoc
+++ b/doc/vector/insns/vror.adoc
@@ -41,7 +41,7 @@ Encoding (Vector-Immediate)::
 [wavedrom, , svg]
 ....
 {reg:[
-{{bits: 7, name: 'OPMVV'},
+{bits: 7, name: 'OPMVV'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'func3'},
 {bits: 5, name: 'imm'},

--- a/doc/vector/insns/vsha256c.adoc
+++ b/doc/vector/insns/vsha256c.adoc
@@ -16,6 +16,7 @@ between these two by other means.
 Encoding (Vector-Vector)::
 [wavedrom, , svg]
 ....
+{reg:[
 {bits: 7, name: 'OPMVV'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'func3'},


### PR DESCRIPTION
Be sure that wavedrom diagrams are surrounded by correct brackets.

Signed-off-by: Stephano Cetola <scetola@linuxfoundation.org>