### PR TITLE
Add vector_create-release workflow to facilitate release management

### DIFF
--- a/.github/workflows/vector_build-pdf.yml
+++ b/.github/workflows/vector_build-pdf.yml
@@ -30,6 +30,9 @@ jobs:
       BUNDLE_GEMFILE: ${{ github.workspace }}/dependencies/Gemfile
       BUNDLE_BIN: ${{ github.workspace }}/bin
       NPM_PACKAGE_FOLDER: ${{ github.workspace }}/dependencies
+    outputs:
+      name: ${{ steps.step1.outputs.name }}
+      pdf-name: ${{ steps.step2.outputs.pdf-name }}
     steps:
     - name: Set output.name
       id: step1

--- a/.github/workflows/vector_build-pdf.yml
+++ b/.github/workflows/vector_build-pdf.yml
@@ -11,17 +11,32 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_call:
+    outputs:
+      name:
+        description: "The base name of the pdf file (without .pdf extensions)"
+        value: ${{ jobs.build.outputs.name }}
+      pdf-name:
+        description: "The name of the pdf file (with .pdf extensions)"
+        value: ${{ jobs.build.outputs.pdf-name }}
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     env:
+      NAME: riscv-crypto-spec-vector
       APT_PACKAGES_FILE: ${{ github.workspace }}/dependencies/apt_packages.txt
       BUNDLE_GEMFILE: ${{ github.workspace }}/dependencies/Gemfile
       BUNDLE_BIN: ${{ github.workspace }}/bin
       NPM_PACKAGE_FOLDER: ${{ github.workspace }}/dependencies
     steps:
+    - name: Set output.name
+      id: step1
+      run: echo "::set-output name=name::$NAME"
+    - name: Set output.pdf-name
+      id: step2
+      run: echo "::set-output name=pdf-name::$NAME.pdf"
     - name: Checkout repository
       uses: actions/checkout@v2
       with:
@@ -56,6 +71,6 @@ jobs:
     - name: Archive PDF result
       uses: actions/upload-artifact@v2
       with:
-        name: riscv-crypto-spec-vector.pdf
-        path: doc/vector/riscv-crypto-spec-vector.pdf
+        name: ${{ env.NAME }}.pdf
+        path: doc/vector/${{ env.NAME }}.pdf
         retention-days: 7

--- a/.github/workflows/vector_create-release.yml
+++ b/.github/workflows/vector_create-release.yml
@@ -1,0 +1,57 @@
+# This work flow includes source and PDF in Release.  It relies on the vector_build-pdf workflow to create the PDF.
+#
+# NOTE: At this time it only runs manually.
+
+name: Create Vector Document Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version, e.g. X.Y.Z:'
+        required: true
+        type: string
+      prerelease:
+        description: 'Tag as a pre-release?'
+        required: false
+        type: boolean
+        default: true
+      draft:
+        description: 'Create release as a draft?'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  build:
+    uses: ./.github/workflows/vector_build-pdf.yml
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: v${{ github.event.inputs.version }}
+        release_name: Release ${{ github.event.inputs.version }}
+        draft: ${{ github.event.inputs.draft }}
+        prerelease: ${{ github.event.inputs.prerelease }}
+    - name: Test env
+      run: echo "name" ${{ needs.build.outputs.name }} "pdf-name" ${{ needs.build.outputs.pdf-name }}
+    - name: Download Artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: ${{ needs.build.outputs.pdf-name }}
+    - name: Upload Release Asset
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path:  ${{ needs.build.outputs.pdf-name }}
+        asset_name:  ${{ needs.build.outputs.name }}_${{ github.event.inputs.version }}.pdf
+        asset_content_type: application/pdf


### PR DESCRIPTION
1. Make the vector_build-pdf.yml workflow re-usable
2. Add new workflow that can be called manually to create a release.  This workflow uses the vector_build-pdf workflow to build and then adds all artifacts into a release. It requests a version string (X.Y.Z), asks the release is a "pre-release" (defaults true), and asks if the release is a "draft release" (defaults false) to help customize the release.


Signed-off-by: Jeff Scheel [jeff@riscv.org](mailto:jeff@riscv.org)