### PR TITLE
rename vghmacc -> vghmac

### DIFF
--- a/doc/vector/insns/vclmul.adoc
+++ b/doc/vector/insns/vclmul.adoc
@@ -61,10 +61,10 @@ It returns the least significant EEW bits of the product.
 This instruction is only defined for `SEW=64`. The use of any other SEW with this instruction is reserved.
 
 Note::
-The 64-bit carryless multiply is used for implementing GCM in the absence of the <<vghmacc,insns-vghmacc>> instruction.
-We do not make these two instructions exclusive as the 64-bit carryless multiply is readily derived from the `vghmacc`
+The 64-bit carryless multiply is used for implementing GCM in the absence of the <<vghmac,insns-vghmac>> instruction.
+We do not make these two instructions exclusive as the 64-bit carryless multiply is readily derived from the `vghmac`
 logic and can have utility in other areas. Likewise, we treat other SEW values as reserved so as not to preclude
-future extensions from using this opcode with different element widths as may be used in generating CRCs, for example.   
+future extensions from using this opcode with different element widths as may be used in generating CRCs, for example.
 
 The other operand can come from a vector register group `vs1`, or a scalar
 integer register `rs1`.

--- a/doc/vector/insns/vghmac.adoc
+++ b/doc/vector/insns/vghmac.adoc
@@ -1,11 +1,11 @@
-[[insns-vghmacc, Vector Carryless Multiply over Galois-Field 2^128]]
-= vghmacc.vv
+[[insns-vghmac, Vector Carryless Multiply over Galois-Field 2^128]]
+= vghmac.vv
 
 Synopsis::
 Vector Carryless Multiply Accumulate over GHASH Galois-Field
 
 Mnemonic::
-vghmacc.vv vd, vs2, vs1
+vghmac.vv vd, vs2, vs1
 
 Encoding::
 [wavedrom, , svg]
@@ -29,7 +29,7 @@ Arguments::
 |Register
 |Direction
 |EGW
-|EGS 
+|EGS
 |EEW
 |Definition
 
@@ -118,8 +118,8 @@ so that the least significant bit is on the left. Thus, instead of the bits bein
 
 This instruction ignores `vtype.vsew`. +
 The number of element groups to be processed is `vl`/`EGS`.
-`vl` must be set to the number of `EEW=32` elements to be processed and 
-therefore must be a multiple of `EGS=4`. + 
+`vl` must be set to the number of `EEW=32` elements to be processed and
+therefore must be a multiple of `EGS=4`. +
 Likewise, `vstart` must be a multiple of `EGS=4`
 
 // It requires that `Zvl128b`be implemented (i.e `VLEN>=128`).
@@ -127,7 +127,7 @@ Likewise, `vstart` must be a multiple of `EGS=4`
 Operation::
 [source,pseudocode]
 --
-function clause execute (VGHMACC(vs2, vs1, vd)) = {
+function clause execute (VGHMAC(vs2, vs1, vd)) = {
   // operands are input with bits reversed in each byte
 
   assert((vl%EGS)<>0)       // vl must be a multiple of EGS
@@ -136,7 +136,7 @@ function clause execute (VGHMACC(vs2, vs1, vd)) = {
   egstart = (vstart/EGS)
 
   foreach (i from egstart to elementgroups) {
-    
+
     let Y = brev(get_velem(vd,EGW=128,i));  // previous partial-hash
     let H = brev(get_velem(vs1,EGW=128,i)); // Hash subkey
     let X = get_velem(vs2,EGW=128,i);       // block cipher output

--- a/doc/vector/riscv-crypto-spec-vector.adoc
+++ b/doc/vector/riscv-crypto-spec-vector.adoc
@@ -175,7 +175,7 @@ include::insns/vbrev8.adoc[leveloffset=+2]
 <<<
 include::insns/vclmul.adoc[leveloffset=+2]
 <<<
-include::insns/vghmacc.adoc[leveloffset=+2]
+include::insns/vghmac.adoc[leveloffset=+2]
 <<<
 include::insns/vclmulh.adoc[leveloffset=+2]
 <<<

--- a/doc/vector/riscv-crypto-vector-zvkg.adoc
+++ b/doc/vector/riscv-crypto-vector-zvkg.adoc
@@ -9,7 +9,7 @@ Instructions for efficiently implementing GCM.
 |EGW
 |Mnemonic
 |Instruction
-| 128 | vghmacc.vv | <<insns-vghmacc>>
+| 128 | vghmac.vv | <<insns-vghmac>>
 
 |===
 


### PR DESCRIPTION
@kdockser / @grnewell Implementing the final rename `vghmacc` -> `vghmac` discussed during Oct 13th crypto TG meeting