### PR TITLE
misc cleanup of vsha2ms and vsm3c

### DIFF
--- a/doc/vector/insns/vsha2ms.adoc
+++ b/doc/vector/insns/vsha2ms.adoc
@@ -29,17 +29,17 @@ Arguments::
 |Register
 |Direction
 |EGW
-|EGS 
+|EGS
 |EEW
 |Definition
 
 | Vd  | input  | 4*SEW  | 4 | SEW | Message words {W[3],  W[2],  W[1],  W[0]}
 | Vs1 | input  | 4*SEW  | 4 | SEW | Message words {W[11], W[10], W[9],  W[4]}
 | Vs2 | input  | 4*SEW  | 4 | SEW | Message words {W[15], W[14], W[13], W[12]}
-| Vd  | output | 4*SEW  | 4 | SEW | Message words {W[19],W[18],W[17],W[16]}
+| Vd  | output | 4*SEW  | 4 | SEW | Message words {W[19], W[18], W[17], W[16]}
 |===
 
-Description:: 
+Description::
 
 - When `SEW`=32, this instruction implements 4 rounds of SHA-256 message
 schedule expansion with EGW=128
@@ -52,14 +52,14 @@ This instruction takes in a subset of the last 16 message-schedule `SEW`-sized "
 and produces the next 4 message-schedule words.
 
 Four `SEW` message schedule words are packed into each `EGW` element group of the
-source and destination registers 
+source and destination registers.
 
 This instructions takes in 11 of the last 16 words of the message schedule. The last 16
 words of the message schedule are shown here in an element group.
 The subscripts show the relative age, where W~0~ is the oldest and W~15~ is the most recent
 of the 16 words.
 
-`{W~3~, W~2~, W~1~, W~0~} + 
+`{W~3~, W~2~, W~1~, W~0~} +
 {W~7~, W~6~, W~5~, W~4~} +
 {W~11~, W~10~, W~9~, W~8~} +
 {W~15~, W~14~, W~13~, W~12~}`
@@ -67,7 +67,7 @@ of the 16 words.
 Since W~5~ through W~8~ are not needed in these calculations, we are able to compact these into
 three element groups
 
-`{W~3~, W~2~, W~1~, W~0~} + 
+`{W~3~, W~2~, W~1~, W~0~} +
 {W~11~, W~10~, W~9~, W~4~} +
 {W~15~, W~14~, W~13~, W~12~}`
 
@@ -77,7 +77,7 @@ three element groups
 The combining of these element groups as shown here can readily be performing using a vector
 vmerge instruction with the appropriate mask
 
-`vmerge {W~11~, W~10~, W~9~, W~4~}, {W~11~, W~10~, W~9~, W~8~}, {W~7~, W~6~, W~5~, W~4~}, V0` 
+`vmerge {W~11~, W~10~, W~9~, W~4~}, {W~11~, W~10~, W~9~, W~8~}, {W~7~, W~6~, W~5~, W~4~}, V0`
 
 
 ====
@@ -87,14 +87,14 @@ The instruction calculates the next 4 words of the message schedule:
 `{W~19~, W~18~, W~17~, W~16~}`
 
 The number of words to be processed is `vl`/`EGS`.
-`vl` must be set to the number of `SEW` elements to be processed and 
-therefore must be a multiple of `EGS=4`. + 
+`vl` must be set to the number of `SEW` elements to be processed and
+therefore must be a multiple of `EGS=4`. +
 Likewise, `vstart` must be a multiple of `EGS=4`
 
 // This instruction requires that `Zvl128b` be implemented (i.e `VLEN>=128`).
 
 
-NB:: W~13~ is not used by the instruction for producing the next 4 message schedule words. 
+NB:: W~13~ is not used by the instruction for producing the next 4 message schedule words.
 
 Question:: Should we require W~13~ to reduce the verification space?
 
@@ -118,29 +118,30 @@ Operation::
 [source,pseudocode]
 --
 function clause execute (VSHA2ms(vs2, vs1, vd)) = {
- // This pseudo code needs to be updated toi support SHA-256 _and_ SHA-512
-	foreach (i from vstart to vl) {
-	  {W[3],  W[2],  W[1],  W[0]}  : bits(EGW) = get_velem(vd, SEW, i};
-	  {W[11], W[10], W[9],  W[4]}  : bits(EGW) = get_velem(vs1, SEW, i};
-	  {W[15], W[14], W[13], W[12]} : bits(EGW) = get_velem(vs2, SEW, i};
+  // This pseudo code needs to be updated toi support SHA-256 _and_ SHA-512
+  foreach (i from vstart to vl) {
+	{W[3],  W[2],  W[1],  W[0]}  : bits(EGW) = get_velem(vd, SEW, i);
+    {W[11], W[10], W[9],  W[4]}  : bits(EGW) = get_velem(vs1, SEW, i);
+    {W[15], W[14], W[13], W[12]} : bits(EGW) = get_velem(vs2, SEW, i);
+  }
 
 
- W[16] = sig1(W[14]) + W[9]  + sig0(W[1]) + W[0];
- W[17] = sig1(W[15]) + W[10] + sig0(W[2]) + W[1];
- W[18] = sig1(W[16])   W[11] + sig0(W[3]) + W[2];
- W[19] = sig1(W[17]) + W[12] + sig0(W[4]) + W[3];
+  W[16] = sig1(W[14]) + W[9]  + sig0(W[1]) + W[0];
+  W[17] = sig1(W[15]) + W[10] + sig0(W[2]) + W[1];
+  W[18] = sig1(W[16]) + W[11] + sig0(W[3]) + W[2];
+  W[19] = sig1(W[17]) + W[12] + sig0(W[4]) + W[3];
 
- // This can also be viewed as
- res[0] = sig1(VS2[2]) + VS1[1]  + sig0(Vd[1]) + Vd[0];
- res[1] = sig1(VS2[3]) + VS1[2] + sig0(Vd[2]) + Vd[1];
- res[2] = sig1(res[0])   VS1[3] + sig0(Vd[3]) + Vd[2];
- res[3] = sig1(res[1]) + VS2[0] + sig0(Vs1[0]) + Vd[3];
- vd = {res[3].res[2],res[1],res[0]};
+  // This can also be viewed as
+  res[0] = sig1(VS2[2]) + VS1[1]  + sig0(Vd[1]) + Vd[0];
+  res[1] = sig1(VS2[3]) + VS1[2] + sig0(Vd[2]) + Vd[1];
+  res[2] = sig1(res[0])   VS1[3] + sig0(Vd[3]) + Vd[2];
+  res[3] = sig1(res[1]) + VS2[0] + sig0(Vs1[0]) + Vd[3];
+  vd = {res[3], res[2], res[1], res[0]};
 
-	set_velem(vd, EGW, i, {W[19],W[18],W[17],W[16]});
+  set_velem(vd, EGW, i, {W[19],W[18],W[17],W[16]});
 
- }
   RETIRE_SUCCESS
+}
 
 // SHA256
 function sig0(x) = ROTR(x,7)  XOR ROTR(x,18) XOR SHR(x,3)
@@ -152,8 +153,7 @@ function sig1(x) = ROTR(x,19) XOR ROTR(x,61) XOR SHR(x,6);
 
 function ROTR(x,n) = (x >> n) | (x << w - n)
 function SHR (x,n) = x >> n
- 
-}
+
 --
 
 Included in::

--- a/doc/vector/insns/vsm3c.adoc
+++ b/doc/vector/insns/vsm3c.adoc
@@ -29,7 +29,7 @@ Arguments::
 |Register
 |Direction
 |EGW
-|EGS 
+|EGS
 |EEW
 |Definition
 
@@ -39,7 +39,7 @@ Arguments::
 | Vd   | output | 256  | 8 | 32 | Next state {A,B,C,D,E,F,G,H}
 |===
 
-Description:: 
+Description::
 Performs 2 rounds of SM3 Compression, producing eight 32-bit outputs in
 a 256-bit 8-element group.
 
@@ -51,7 +51,7 @@ Note::
 The rounds number is used in the rotation of the constant as well to inform the
 behavior which differs between rounds 0-15, and rounds 16-63.
 
-It treats each 256-bit 8-element group of `vd` as eight 32-bit words,  
+It treats each 256-bit 8-element group of `vd` as eight 32-bit words,
 and each 256-bit 8-element group of `vs2` as eight 32-bit words. Only 4 of these words are consumed by
 this instruction, the rest are don't-cares.
 
@@ -71,10 +71,10 @@ This instruction consumes the "W" message schedule inputs and internally generat
 // It probably makes sense to have vs1 and vs2 hold eight 32-bit words each and have 4 versions of this instruction;
 // one for each pair of inputs.
 // This fits more naturally with the generating instructions and doesn't leave us with the oddity of 64-bit and 256-bit element groups
-// Vd (in) = {A,B,C,D,E,F,G,H} 
+// Vd (in) = {A,B,C,D,E,F,G,H}
 // vs1 = W[0:7]  // 8 expanded words
 // vs2 = W’[0:7] // 8 expanded words with XORing
-// Vd (out) = {A,B,C,D,E,F,G,H} 
+// Vd (out) = {A,B,C,D,E,F,G,H}
 
 
 
@@ -87,7 +87,7 @@ This instruction requires that `Zvl128b` be implemented (i.e `VLEN>=128`).
 Operation::
 [source,pseudocode]
 --
-function clause execute (VAESESFK1(rnd, vs2)) = {
+function clause execute (VSM3C(rnd, vs2)) = {
   assert((vl%EGS)<>0)       // vl must be a multiple of EGS
   assert((vstart%EGS)<>0) //  vstart must be a multiple of EGS
   // assert round key in range
@@ -95,10 +95,10 @@ function clause execute (VAESESFK1(rnd, vs2)) = {
   elementgroups = (vl/EGS)
   egstart = (vstart/EGS)
   vlen = vl/EGS
-  
-  
-// your code goes here
- SS1 <- ROTL7((ROTL12(A) + E + (ROTLjmod32(T_j))
+
+
+  // your code goes here
+  SS1 <- ROTL7((ROTL12(A) + E + (ROTLjmod32(T_j))
   SS2 <- SS1 xor ROTL12(A)
   TT1 <- FF_j(A, B, C) + D + SS2 + W'[i]
   TT2 <- GG_j(E, F, G) + H + SS1 + W[i]
@@ -124,10 +124,8 @@ function clause execute (VAESESFK1(rnd, vs2)) = {
   F <- E1
   E2 <- P_0(TT2)
 
-Output: {A2, A1, C2, C1, E2, E1, G2, G1}
+  Output: {A2, A1, C2, C1, E2, E1, G2, G1}
 
-
-  }
   RETIRE_SUCCESS
 }
 --


### PR DESCRIPTION
Various cleanup for @kdockser review

Another thing;
It seems like the ordering of vector elements in the descriptions and the pseudo-code is not consistent (issue also raised in https://github.com/riscv/riscv-crypto/issues/190), should we have `{elt0, elt1, elt2, ...}` or `{..., elt2, elt1, elt0}` ?