### PR TITLE
Clarifying aes element group

### DIFF
--- a/doc/vector/insns/vaesdf.adoc
+++ b/doc/vector/insns/vaesdf.adoc
@@ -56,7 +56,14 @@ Arguments::
 Description:: 
 Perform the final-round decryption function of the AES block cipher.
 
-The inputs and outputs to this instruction are comprised of 128-bit element groups.  Each `EGW=128` element group of source `vd` holds the current round state and each `EGW=128` element group of `vs2` holds the round key. Each `EGW=128` element group next round state output is produced by applying the InvShiftRows, InvSubBytes,  and AddRoundkey steps to the corresponding inputs.
+The inputs and outputs to this instruction are comprised of 128-bit element groups.  Each `EGW=128` element group of source `vd` holds the current round state and each `EGW=128` element group of `vs2` holds the round key.
+
+In the case of the `.vs` form of the instruction, element group 0 of the single register `vs2` holds a single element group that is used
+as the round key for all of the element groups in `vd`. While in this case `vs2` is a single register,
+`vd` can be a register group. 
+
+Each `EGW=128` element group next round state output is produced by applying the InvShiftRows, InvSubBytes,  and AddRoundkey steps to the corresponding inputs and is written to each `EGW=128` element group of `vd`.
+
 This instruction must always be implemented such that its execution latency does not depend
 on the data being operated upon.    
 
@@ -72,6 +79,12 @@ The number of element groups to be processed is `vl`/`EGS`.
 `vl` must be set to the number of `EEW=32` elements to be processed and 
 therefore must be a multiple of `EGS=4`. + 
 Likewise, `vstart` must be a multiple of `EGS=4`
+
+Note::
+Since the least significant element group of register `vs2` is used for all element groups in register groups `vd`
+and `vs2`, the destination vector register group cannot overlap with the single `vs` vector register,
+otherwise the instruction encoding is reserved.
+
 
 Operation::
 [source,sail]

--- a/doc/vector/insns/vaesdf.adoc
+++ b/doc/vector/insns/vaesdf.adoc
@@ -81,7 +81,7 @@ therefore must be a multiple of `EGS=4`. +
 Likewise, `vstart` must be a multiple of `EGS=4`
 
 Note::
-Since the least significant element group of register `vs2` is used for all element groups in register groups `vd`
+For the `.vs` form, since the least significant element group of register `vs2` is used for all element groups in register groups `vd`
 and `vs2`, the destination vector register group cannot overlap with the single `vs` vector register,
 otherwise the instruction encoding is reserved.
 

--- a/doc/vector/insns/vaesdm.adoc
+++ b/doc/vector/insns/vaesdm.adoc
@@ -57,7 +57,13 @@ Description::
 This instruction implements the middle-round decryption function of the AES
 block cipher.
 
-The inputs and outputs to this instruction are comprised of 128-bit element groups.  Each `EGW=128` element group of source `vd` holds the current round state and each `EGW=128` element group of `vs1` holds the round key. Each `EGW=128` element group next round state output is produced by applying the ShiftRows, SubBytes,  and AddRoundkey steps to the corresponding inputs.
+The inputs and outputs to this instruction are comprised of 128-bit element groups.  Each `EGW=128` element group of source `vd` holds the current round state and each `EGW=128` element group of `vs2` holds the round key.
+
+In the case of the `.vs` form of the instruction, element group 0 of the single register `vs2` holds a single element group that is used
+as the round key for all of the element groups in `vd`. While in this case `vs2` is a single register,
+`vd` can be a register group. 
+
+Each `EGW=128` element group next round state output is produced by applying the ShiftRows, SubBytes,  and AddRoundkey steps to the corresponding inputs and is written to each `EGW=128` element group of `vd`.
 
 This instruction must always be implemented such that its execution latency does not depend
 on the data being operated upon.    
@@ -73,6 +79,12 @@ This instruction ignores `vtype.vsew`. +
 The number of element groups to be processed is `vl`/`EGS`.
 `vl` must be set to the number of `EEW=32` elements to be processed and 
 therefore must be a multiple of `EGS=4`. + 
+
+Note::
+Since the least significant element group of register `vs2` is used for all element groups in register groups `vd`
+and `vs2`, the destination vector register group cannot overlap with the single `vs` vector register,
+otherwise the instruction encoding is reserved.
+
 
 Operation::
 [source,sail]

--- a/doc/vector/insns/vaesdm.adoc
+++ b/doc/vector/insns/vaesdm.adoc
@@ -81,7 +81,7 @@ The number of element groups to be processed is `vl`/`EGS`.
 therefore must be a multiple of `EGS=4`. + 
 
 Note::
-Since the least significant element group of register `vs2` is used for all element groups in register groups `vd`
+For the `.vs` form, since the least significant element group of register `vs2` is used for all element groups in register groups `vd`
 and `vs2`, the destination vector register group cannot overlap with the single `vs` vector register,
 otherwise the instruction encoding is reserved.
 

--- a/doc/vector/insns/vaesef.adoc
+++ b/doc/vector/insns/vaesef.adoc
@@ -60,7 +60,9 @@ In the case of the `.vs` form of the instruction, element group 0 of the single 
 as the round key for all of the element groups in `vd`. While in this case `vs2` is a single register,
 `vd` can be a register group. 
 The next round state output of each element group is produced by applying the SubBytes, ShiftRows, and AddRoundkey
-steps to the corresponding inputs. This instruction must always be implemented such that its execution latency does not
+steps to the corresponding inputs and is written to each `EGW=128` element group of `vd`.
+
+This instruction must always be implemented such that its execution latency does not
 depend on the data being operated upon.    
 
 * SubBytes(state)
@@ -70,8 +72,7 @@ depend on the data being operated upon.
 //(ASIICDOC limitation???: Can't end on a bullet)
 
 Note::
-This is true for all .vs instructions in the Vector Crypto Extensions - COPY THIS TO THE OTHER INSTRUCTIONS
-Since the least significant element group of register `vs2` is used for all element groups in register groups `vd`
+For the `.vs` form, since the least significant element group of register `vs2` is used for all element groups in register groups `vd`
 and `vs2`, the destination vector register group cannot overlap with the single `vs` vector register,
 otherwise the instruction encoding is reserved.
 

--- a/doc/vector/insns/vaesem.adoc
+++ b/doc/vector/insns/vaesem.adoc
@@ -55,8 +55,11 @@ Arguments::
 
 Description:: 
 This instruction implements the middle-round function of the AES block cipher.
-It treats each `EGW=128` element group of `vs2` as the current AES round state,
-and each `EGW=128` element group of `vs1` as the round key.
+It treats each `EGW=128` element group of `vd` as the current AES round state,
+and each `EGW=128` element group of `vs2` as the round key.
+In the case of the `.vs` form of the instruction, element group 0 of the single register `vs2` holds a single element group that is used
+as the round key for all of the element groups in `vd`. While in this case `vs2` is a single register,
+`vd` can be a register group. 
 
 The result (i.e. the next round state) is written to each `EGW=128` element group of `vd`.
 
@@ -69,7 +72,7 @@ Likewise, `vstart` must be a multiple of `EGS=4`
 // This instruction requires that `Zvl128b` be implemented (i.e `VLEN>=128`).
 
 Note::
-Since the least significant element group of register `vs2` is used for all element groups in register groups `vd`
+For the `.vs` form, since the least significant element group of register `vs2` is used for all element groups in register groups `vd`
 and `vs2`, the destination vector register group cannot overlap with the single `vs` vector register,
 otherwise the instruction encoding is reserved.
 

--- a/doc/vector/insns/vaesem.adoc
+++ b/doc/vector/insns/vaesem.adoc
@@ -68,6 +68,12 @@ Likewise, `vstart` must be a multiple of `EGS=4`
 
 // This instruction requires that `Zvl128b` be implemented (i.e `VLEN>=128`).
 
+Note::
+Since the least significant element group of register `vs2` is used for all element groups in register groups `vd`
+and `vs2`, the destination vector register group cannot overlap with the single `vs` vector register,
+otherwise the instruction encoding is reserved.
+
+
 Operation::
 [source,pseudocode]
 --


### PR DESCRIPTION
@kdockser some suggestions to unify AES single round descriptions (in particular `.vs` variant).