### PR TITLE
Fixing vaeskf2/vaeskr2  imm ranges to match NIST spec

### DIFF
--- a/doc/vector/insns/vaeskf2.adoc
+++ b/doc/vector/insns/vaeskf2.adoc
@@ -43,7 +43,7 @@ Description::
 This instruction implements a single round of the forward AES-256 KeySchedule.
 It treats each `EGW=128` element group of `vs2` as the current AES round key,
 and each `EGW=128` element group of `vd` as the previous AES round key.
-The round number is stored in the unsigned 5-bit `rnd` immediate. Legal values are 1 - 14.
+The round number is stored in the unsigned 5-bit `rnd` immediate. Legal values are 2 - 14.
 Out of range values signal an illegal instruction exception.
 
 It applies a single AES-256 KeySchedule round to each element group, and

--- a/doc/vector/insns/vaeskr2.adoc
+++ b/doc/vector/insns/vaeskr2.adoc
@@ -43,7 +43,7 @@ Description::
 This instruction implements a single round of the reverse AES-256 KeySchedule.
 It treats each 128-bit element group of `vs2` as the current AES round key,
 and each 128-bit element group of `vd` as the next (in forward sequence) AES round key.
-The round number is stored in the unsigned 5-bit `rnd` immediate. Legal values are 1 - 10.
+The round number is stored in the unsigned 5-bit `rnd` immediate. Legal values are 2 - 14.
 Out of range values signal an illegal instruction exception.
 
 It applies a single AES-256 KeySchedule round to each element group, and


### PR DESCRIPTION
Signed-off-by: Nicolas Brunie <82109999+nibrunieAtSi5@users.noreply.github.com>

In AES NITS standard, it seems key schedule round 0 and 1 corresponds to the two 128-bit chunk of the original AES-256 key. Key expansion should start at round 2 (for a total of 15 128-bit round keys, 2 original and 13 generated).

Similarly for the revser key schedule, it looks like `round[13].ik_sch` and `round[14].ik_sch ` corresponds to the initial 256-bit key.

(Issue reported by @melharhar.)

from https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.197.pdf section 5.3
![image](https://user-images.githubusercontent.com/82109999/197403846-415257a0-0cc4-4e64-9d13-19acd98f20b1.png)
