### PR TITLE
various fix suggestion in the first sections

### DIFF
--- a/doc/vector/riscv-crypto-vector-audience.adoc
+++ b/doc/vector/riscv-crypto-vector-audience.adoc
@@ -41,8 +41,7 @@ In particular, they should be aware of the literature around efficiently
 implementing AES and SM4 SBoxes in hardware.
 
 Verification engineers::
-Responsible for ensuring the correct implementation of the extension
-in hardware.
+Responsible for ensuring the correct implementation of the extensions in hardware.
 No cryptography background is assumed.
 We expect them to identify interesting test cases from the
 specification. An understanding of their real-world usage will help with this.

--- a/doc/vector/riscv-crypto-vector-element-groups.adoc
+++ b/doc/vector/riscv-crypto-vector-element-groups.adoc
@@ -1,7 +1,7 @@
 [[crypto-vector-element-groups]]
 === Crypto Vector Element Groups
 
-Many vector crypto instructions operate on larger operands than instructions in the base vector extension. Typically, these operands are 128- and 256-bits wide. In many cases, these operands are comprised of smaller elements that are combined. However, in other cases these operands are a single value. For example, AES operates on 128-bit blocks comprised of four 32-bit words using 128-bit round keys that are generated from 128-, 192-, and 256-bit cipher keys.
+Many vector crypto instructions operate on larger operands than instructions in the base vector extension. Typically, these operands are 128- and 256-bit wide. In many cases, these operands are comprised of smaller elements that are combined. However, in other cases these operands are a single value. For example, AES operates on 128-bit blocks comprised of four 32-bit words using 128-bit round keys that are generated from 128-, 192-, and 256-bit cipher keys.
 
 In order to be compatible with the 32- and 64-bit element widths of the base vector instructions,
 we treat these operands as a vector of one of more element groups (see 
@@ -15,15 +15,15 @@ that operates on them:
 - Effective Element Width (EEW) - number of bits in each element
 
 When the EEW is explicitly defined for a vector crypto instruction, the current `SEW` is ignored by that instruction.
-This was done to enable other SEW values to be used without requiring an additional `vsetvl` instruction.
+This was done to enable other SEW values to be used without requiring an additional `vsetvl` instruction (or one of its variants).
 
 As with all vector instructions, the number of elements processed by a vector instruction is specified by the
 vector length `vl`. The number of element groups operated upon is then `vl`/`EGS`.
-Attempting to execute a Vector Crypto Instruction when this this ratio is not an
+Attempting to execute a Vector Crypto Instruction when this ratio is not an
 integral value will result in an illegal instruction exception.
 
 Tip::
-To help ensure that the proper `vl` is used, programmers are encouraged to set SEW to the match the EEW of the
+To help ensure that the proper `vl` is used, programmers are encouraged to set SEW to match the EEW of the
 instructions being executed.
 
 Since `vstart` is expressed in elements, the starting element group is `vstart`/`EGS`. 

--- a/doc/vector/riscv-crypto-vector-introduction.adoc
+++ b/doc/vector/riscv-crypto-vector-introduction.adoc
@@ -2,7 +2,7 @@
 == Introduction
 
 This document describes the proposed _vector_ cryptography
-extension for RISC-V.
+extensions for RISC-V.
 All instructions proposed here are based on the Vector registers.
 The instructions are designed to be highly performant, with large
 application and server-class cores being the main target.


### PR DESCRIPTION
- Trying to uniformize `cryptography extension` to `cryptography extensions` (which was already used and seems to better describe the actual multi-extension content of the spec) 
- various suggestions to fix potential typos