### PR TITLE
another round of fix suggestions

### DIFF
--- a/doc/vector/insns/vaesz.adoc
+++ b/doc/vector/insns/vaesz.adoc
@@ -54,7 +54,7 @@ Note::
 This instruction is needed to avoid the need to "splat" a 128-bit vector register group when the round key is the same for
 all 128-bit "lanes". Such a splat would typically be implemented with a `vrgather` instruction which would hurt performance
 in many implementations. 
-This instruction only exists in the .vs form because the .vv form would be identical to the VXOR instruction.
+This instruction only exists in the `.vs` form because the `.vv` form would be identical to the VXOR instruction.
 
 - AddRoundKey(state,roundkey)
 
@@ -69,7 +69,7 @@ otherwise the instruction encoding is reserved.
 Operation::
 [source,sail]
 --
-function clause execute (VAESZ(vs1, vd) = {
+function clause execute (VAESZ(vs2, vd) = {
   assert((vl%EGS)<>0)       // vl must be a multiple of EGS
   assert((vstart%EGS)<>0) //  vstart must be a multiple of EGS
 

--- a/doc/vector/insns/vandn.adoc
+++ b/doc/vector/insns/vandn.adoc
@@ -107,8 +107,8 @@ function clause execute (VANDN(vs2, vs1, vd, suffix)) = {
   foreach (i from vstart to vl-1) {
     let op1 = match suffix {
       "vv" => get_velem(vs1, EEW=SEW, i),
-      "vx" => sext_or_truncate_to_sew(X(rs1)),
-      "vi" => sext(imm)
+      "vx" => sext_or_truncate_to_sew(X(vs1)),
+      "vi" => sext(vs1)
     };
     let op2 = get_velem(vs2, EEW=SEW, i); 
     set_velem(vd, EEW=SEW, i, op & ~op2);

--- a/doc/vector/riscv-crypto-vector-zvkb.adoc
+++ b/doc/vector/riscv-crypto-vector-zvkb.adoc
@@ -16,6 +16,6 @@ for implementing common cryptographic workloads securely & efficiently.
 | vror.[vv,vx,vi]    | <<insns-vror>>
 | vbrev8.v           | <<insns-vbrev8>>
 | vrev8.v            | <<insns-vrev8>>
-| vandn.[vv,vs,vx]   | <<insns-vandn>>
+| vandn.[vv,vx,vi]   | <<insns-vandn>>
 |===
 

--- a/doc/vector/riscv-crypto-vector-zvknh.adoc
+++ b/doc/vector/riscv-crypto-vector-zvknh.adoc
@@ -50,6 +50,6 @@ for accelerated cryptographic operations.
 // | 128
 | vsha2ms.vv   | <<insns-vsha2ms>>
 // | 128
-| vsha2c.vv    | <<insns-vsha2c>>
+| vsha2c[hl].vv    | <<insns-vsha2c>>
 |===
 


### PR DESCRIPTION
`vandn` pseudo-code fix is up for debate: we used undefined variables `rs1` and `imm`. Is it better to use `vs1` everywhere (less meaningful) or to copy it into `rs1` and `imm` first.