### PR TITLE
updating various encoding to avoid confusion

### DIFF
--- a/doc/vector/insns/vclmul.adoc
+++ b/doc/vector/insns/vclmul.adoc
@@ -18,7 +18,7 @@ Encoding (Vector-Vector)::
 {bits: 5, name: 'vs1'},
 {bits: 5, name: 'vs2'},
 {bits: 1, name: 'vm'},
-{bits: 6, name: 'funct6'},
+{bits: 6, name: '001100'},
 ]}
 ....
 
@@ -32,7 +32,7 @@ Encoding (Vector-Scalar)::
 {bits: 5, name: 'rs1'},
 {bits: 5, name: 'vs2'},
 {bits: 1, name: 'vm'},
-{bits: 6, name: 'funct6'},
+{bits: 6, name: '001100'},
 ]}
 ....
 

--- a/doc/vector/insns/vclmul.adoc
+++ b/doc/vector/insns/vclmul.adoc
@@ -17,7 +17,7 @@ Encoding (Vector-Vector)::
 {bits: 3, name: 'OPIVV'},
 {bits: 5, name: 'vs1'},
 {bits: 5, name: 'vs2'},
-{bits: 1, name: '1'},
+{bits: 1, name: 'vm'},
 {bits: 6, name: 'funct6'},
 ]}
 ....
@@ -31,7 +31,7 @@ Encoding (Vector-Scalar)::
 {bits: 3, name: 'OPIVX'},
 {bits: 5, name: 'rs1'},
 {bits: 5, name: 'vs2'},
-{bits: 1, name: '1'},
+{bits: 1, name: 'vm'},
 {bits: 6, name: 'funct6'},
 ]}
 ....

--- a/doc/vector/insns/vclmulh.adoc
+++ b/doc/vector/insns/vclmulh.adoc
@@ -17,8 +17,8 @@ Encoding (Vector-Vector)::
 {bits: 3, name: 'OPIVV'},
 {bits: 5, name: 'vs1'},
 {bits: 5, name: 'vs2'},
-{bits: 1, name: '1'},
-{bits: 6, name: 'funct6'},
+{bits: 1, name: 'vm'},
+{bits: 6, name: '001101'},
 ]}
 ....
 
@@ -31,8 +31,8 @@ Encoding (Vector-Scalar)::
 {bits: 3, name: 'OPIVX'},
 {bits: 5, name: 'rs1'},
 {bits: 5, name: 'vs2'},
-{bits: 1, name: '1'},
-{bits: 6, name: 'funct6'},
+{bits: 1, name: 'vm'},
+{bits: 6, name: '001101'},
 ]}
 ....
 


### PR DESCRIPTION
Signed-off-by: Nicolas Brunie <82109999+nibrunieAtSi5@users.noreply.github.com>

@kdockser , I know you told us to wait for finalized opcode allocation before updating the spec, but if you don't mind I will like to update some of it nonetheless (knowing that this may not be the final allocation). Some people are finding the discrepancies between the spreadsheet and the spec misleading.

we could reduce this PR to only modify the `vm` bit (and leave the `funct6` as a placehold, since this is not a source of confusion)