### PR TITLE
undefined instruction exception -> illegal instruction exception

### DIFF
--- a/doc/vector/insns/vsha2c.adoc
+++ b/doc/vector/insns/vsha2c.adoc
@@ -69,7 +69,7 @@ Description::
 - When `SEW`=32, this instruction implements 2 rounds of SHA-256 compression with EGW=128 (`zvknha` and `zvknhb`)
 - When `SEW`=64, this instruction implements 2 rounds of SHA-512 compression with EGW=256 (`zvkhnb` only)
 
-If SEW is other than 32 or 64, this instruction takes the undefined instruction exception.
+If SEW is other than 32 or 64, this instruction takes the illegal instruction exception.
 
 [NOTE]
 ====

--- a/doc/vector/insns/vsha2ms.adoc
+++ b/doc/vector/insns/vsha2ms.adoc
@@ -46,7 +46,7 @@ schedule expansion with EGW=128 (`zvknha` and `zvknhb`)
 - When `SEW`=64, this instruction implements 4 rounds of SHA-512 message
 schedule expansion with EGW=256 (`zvknhb` only)
 
-If SEW is other than 32 or 64, this instruction takes the undefined instruction exception.
+If SEW is other than 32 or 64, this instruction takes the illegal instruction exception.
 
 This instruction takes in a subset of the last 16 message-schedule `SEW`-sized "words"
 and produces the next 4 message-schedule words.


### PR DESCRIPTION
The vector spec does not mention "undefined instruction exception" but only "illegal instruction exception", and it seems `vaeskf*` already use the term "illegal instruction exception"