### PR TITLE
Minor typo in vror description

### DIFF
--- a/doc/vector/insns/vrol.adoc
+++ b/doc/vector/insns/vrol.adoc
@@ -4,7 +4,7 @@
 Synopsis::
 Vector rotate left by vector/scalar.
 
-Only the log2(SEW) bits are used for the rotate amount.
+Only the low log2(SEW) bits are used for the rotate amount.
 
 Mnemonic::
 vrol.vv vd, vs2, vs1, vm +

--- a/doc/vector/insns/vror.adoc
+++ b/doc/vector/insns/vror.adoc
@@ -4,7 +4,7 @@
 Synopsis::
 Vector rotate right by vector/scalar/immediate.
 
-Only the lowest log2(SEW) bits are used for the rotate amount.
+Only the low log2(SEW) bits are used for the rotate amount.
 
 [NOTE]
 ====

--- a/doc/vector/insns/vror.adoc
+++ b/doc/vector/insns/vror.adoc
@@ -4,11 +4,11 @@
 Synopsis::
 Vector rotate right by vector/scalar/immediate.
 
-Only the log2(SEW) bits are used for the rotate amount.
+Only the lowest log2(SEW) bits are used for the rotate amount.
 
 [NOTE]
 ====
-The ``.vi` form of this instruction uses a 6-bit unsigned immediate value that is specified
+The `.vi` form of this instruction uses a 6-bit unsigned immediate value that is specified
 in bits 26,19:15 of the instruction encoding.
 ====
 


### PR DESCRIPTION
Signed-off-by: Nicolas Brunie <82109999+nibrunieAtSi5@users.noreply.github.com>

~~'lowest' could even be replaced by 'low' to match the full phrase in the description. ~~