### PR TITLE
updating missing funct6/funct5 opcode fields

### DIFF
--- a/doc/vector/insns/vandn.adoc
+++ b/doc/vector/insns/vandn.adoc
@@ -19,7 +19,7 @@ Encoding (Vector-Vector)::
 {bits: 5, name: 'vs1'},
 {bits: 5, name: 'vs2'},
 {bits: 1, name: 'vm'},
-{bits: 6, name: 'funct6'},
+{bits: 6, name: '000001'},
 ]}
 ....
 
@@ -33,7 +33,7 @@ Encoding (Vector-Scalar)::
 {bits: 5, name: 'rs1'},
 {bits: 5, name: 'vs2'},
 {bits: 1, name: 'vm'},
-{bits: 6, name: 'funct6'},
+{bits: 6, name: '000001'},
 ]}
 ....
 
@@ -47,7 +47,7 @@ Encoding (Vector-Immediate)::
 {bits: 5, name: 'imm'},
 {bits: 5, name: 'vs2'},
 {bits: 1, name: 'vm'},
-{bits: 6, name: 'funct6'},
+{bits: 6, name: '000001'},
 ]}
 ....
 

--- a/doc/vector/insns/vbrev8.adoc
+++ b/doc/vector/insns/vbrev8.adoc
@@ -14,10 +14,10 @@ Encoding (Vector)::
 {bits: 7, name: 'OP-V'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'OPIVV'},
-{bits: 5, name: 'funct5'},
+{bits: 5, name: '01000'},
 {bits: 5, name: 'vs2'},
 {bits: 1, name: 'vm'},
-{bits: 6, name: 'funct6'},
+{bits: 6, name: '010010'},
 ]}
 ....
 
@@ -29,7 +29,7 @@ Arguments::
 |Register
 |Direction
 |EGW
-|EGS 
+|EGS
 |EEW
 |Definition
 
@@ -37,7 +37,7 @@ Arguments::
 | Vd  | output | SEW  | 1 | SEW | Bit-reversed bytes
 |===
 
-Description:: 
+Description::
 This instruction reverses the order of the bits in each byte in `vs2`.
 
 Operation::
@@ -48,7 +48,7 @@ function clause execute (VBREV8(vs2)) = {
   foreach (i from vstart to vl-1) {
     let input = get_velem(vs2, SEW, i);
     let output : bits(SEW) = 0;
-    foreach (i from 0 to SEW-8 by 8) 
+    foreach (i from 0 to SEW-8 by 8)
       let output[i+7..i] = reverse_bits_in_byte(input[i+7..i]);
     set_velem(vd, SEW, i, output)
   }

--- a/doc/vector/insns/vghmac.adoc
+++ b/doc/vector/insns/vghmac.adoc
@@ -17,7 +17,7 @@ Encoding::
 {bits: 5, name: 'vs1'},
 {bits: 5, name: 'vs2'},
 {bits: 1, name: '1'},
-{bits: 6, name: 'funct6'},
+{bits: 6, name: '101100'},
 ]}
 ....
 

--- a/doc/vector/insns/vrev8.adoc
+++ b/doc/vector/insns/vrev8.adoc
@@ -14,10 +14,10 @@ Encoding (Vector)::
 {bits: 7, name: 'OP-V'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'OPIVV'},
-{bits: 5, name: 'funct5'},
+{bits: 5, name: '01001'},
 {bits: 5, name: 'vs2'},
 {bits: 1, name: 'vm'},
-{bits: 6, name: 'funct6'},
+{bits: 6, name: '010010'},
 ]}
 ....
 
@@ -29,7 +29,7 @@ Arguments::
 |Register
 |Direction
 |EGW
-|EGS 
+|EGS
 |EEW
 |Definition
 
@@ -37,7 +37,7 @@ Arguments::
 | Vd  | output | SEW  | 1 | SEW | Byte-reversed elements
 |===
 
-Description:: 
+Description::
 This instruction reverses the order of the bytes in each element of `vs2`, effectively performing an element-wise endian swap.
 
 [NOTE]

--- a/doc/vector/insns/vrol.adoc
+++ b/doc/vector/insns/vrol.adoc
@@ -8,7 +8,7 @@ Only the low log2(SEW) bits are used for the rotate amount.
 
 Mnemonic::
 vrol.vv vd, vs2, vs1, vm +
-vrol.vx vd, vs2, rs1, vm + 
+vrol.vx vd, vs2, rs1, vm +
 
 Encoding (Vector-Vector)::
 [wavedrom, , svg]

--- a/doc/vector/insns/vsha2c.adoc
+++ b/doc/vector/insns/vsha2c.adoc
@@ -18,7 +18,7 @@ We are evaluating if there is an advantage to having two versions of this instru
 having one version and using a slideDown or the like between invocations.
 ====
 
-Encoding (Vector-Vector)::
+Encoding (Vector-Vector) High part::
 [wavedrom, , svg]
 ....
 {reg:[
@@ -28,11 +28,11 @@ Encoding (Vector-Vector)::
 {bits: 5, name: 'vs1'},
 {bits: 5, name: 'vs2'},
 {bits: 1, name: '1'},
-{bits: 6, name: 'funct6'},
+{bits: 6, name: '101110'},
 ]}
 ....
 
-Encoding (Vector-Vector)::
+Encoding (Vector-Vector) Low part::
 [wavedrom, , svg]
 ....
 {reg:[
@@ -42,7 +42,7 @@ Encoding (Vector-Vector)::
 {bits: 5, name: 'vs1'},
 {bits: 5, name: 'vs2'},
 {bits: 1, name: '1'},
-{bits: 6, name: 'funct6'},
+{bits: 6, name: '101111'},
 ]}
 ....
 

--- a/doc/vector/insns/vsha2ms.adoc
+++ b/doc/vector/insns/vsha2ms.adoc
@@ -17,7 +17,7 @@ Encoding (Vector-Vector)::
 {bits: 5, name: 'vs1'},
 {bits: 5, name: 'vs2'},
 {bits: 1, name: '1'},
-{bits: 6, name: 'funct6'},
+{bits: 6, name: '101101'},
 ]}
 ....
 

--- a/doc/vector/insns/vsm3c.adoc
+++ b/doc/vector/insns/vsm3c.adoc
@@ -17,7 +17,7 @@ Encoding::
 {bits: 5, name: 'uimm'},
 {bits: 5, name: 'vs2'},
 {bits: 1, name: '1'},
-{bits: 6, name: 'funct6'},
+{bits: 6, name: '101011'},
 ]}
 ....
 

--- a/doc/vector/insns/vsm3me.adoc
+++ b/doc/vector/insns/vsm3me.adoc
@@ -17,7 +17,7 @@ Encoding::
 {bits: 5, name: 'vs1'},
 {bits: 5, name: 'vs2'},
 {bits: 1, name: '1'},
-{bits: 6, name: 'funct6'},
+{bits: 6, name: '100000'},
 ]}
 ....
 
@@ -29,7 +29,7 @@ Arguments::
 |Register
 |Direction
 |EGW
-|EGS 
+|EGS
 |EEW
 |Definition
 
@@ -38,7 +38,7 @@ Arguments::
 | Vd  | output | 256  | 8 | 32 | Message words W[16:23]
 |===
 
-Description:: 
+Description::
 This instruction implements 8 rounds of SM3 message expansion,  producing eight 32-bit
 outputs in a 256-bit 8-element group.
 It treats each 256-bit 8-element group of `vs1` and `vs2` as the data input.

--- a/doc/vector/insns/vsm4k.adoc
+++ b/doc/vector/insns/vsm4k.adoc
@@ -17,7 +17,7 @@ Encoding::
 {bits: 5, name: 'uimm'},
 {bits: 5, name: 'vs2'},
 {bits: 1, name: '1'},
-{bits: 6, name: 'funct6'},
+{bits: 6, name: '100001'},
 ]}
 ....
 
@@ -29,7 +29,7 @@ Arguments::
 |Register
 |Direction
 |EGW
-|EGS 
+|EGS
 |EEW
 |Definition
 
@@ -38,7 +38,7 @@ Arguments::
 | Vd   | output | 128  | 4 | 32 | Next 4 round keys rK'[0:3]
 |===
 
-Description:: 
+Description::
 This instruction implements 4 rounds of the SM4 Key Expansion, producing four 32-bit round keys
 as defined in SM4 (see
 link:https://www.rfc-editor.org/rfc/rfc8998.html[RFC 8998 ShangMi (SM) Cipher Suites for TLS 1.3]).

--- a/doc/vector/insns/vsm4r.adoc
+++ b/doc/vector/insns/vsm4r.adoc
@@ -14,10 +14,10 @@ Encoding::
 {bits: 7, name: 'OP-P'},
 {bits: 5, name: 'vd'},
 {bits: 3, name: 'OPMVV'},
-{bits: 5, name: 'funct5'},
+{bits: 5, name: '10000'},
 {bits: 5, name: 'vs2'},
 {bits: 1, name: '1'},
-{bits: 6, name: 'funct6'},
+{bits: 6, name: '101000'},
 ]}
 ....
 
@@ -29,7 +29,7 @@ Arguments::
 |Register
 |Direction
 |EGW
-|EGS 
+|EGS
 |EEW
 |Definition
 
@@ -38,7 +38,7 @@ Arguments::
 | Vd   | output | 128  | 4 | 32 | Next state X'[0:3]
 |===
 
-Description:: 
+Description::
 This instruction implements 4 rounds of SM4 Encryption/Decryption, producing four 32-bit outputs in
 a 128-bit 4-element group.
 It treats each 128-bit 4-element group of `vs2` as the four round keys and

--- a/doc/vector/riscv-crypto-vector-inst-table-zvkb.adoc
+++ b/doc/vector/riscv-crypto-vector-inst-table-zvkb.adoc
@@ -35,7 +35,7 @@ Vector instructions with *Zvkb (in bold)*
 | 001100 |V|X|I| vrgather   | 001100 |V|X| *vclmul*    | 001100 | | |
 | 001101 | | | |            | 001101 |V|X| *vclmulh*   | 001101 | | |
 | 001110 | |X|I| vslideup   | 001110 | |X| vslide1up   | 001110 | |F| vfslide1up
-| 001110 |V| | | vrgatherei16|        | | |             |        | | |           
+| 001110 |V| | | vrgatherei16|        | | |             |        | | |
 | 001111 | |X|I| vslidedown | 001111 | |X| vslide1down | 001111 | |F| vfslide1down
 |===
 
@@ -50,7 +50,7 @@ Vector instructions with *Zvkb (in bold)*
 | 010011 |V|X| | vmsbc      | 010011 | | |             | 010011 |V| | VFUNARY1
 | 010100 |V|X| | *vror*     | 010100 |V| | VMUNARY0    | 010100 | | |
 | 010101 |V|X| | *vrol*     | 010101 | | |             | 010101 | | |
-| 01010x | | |I| *vror*     |        | | |             |        | | |    
+| 01010x | | |I| *vror*     |        | | |             |        | | |
 | 010110 | | | |            | 010110 | | |             | 010110 | | |
 | 010111 |V|X|I| vmerge/vmv | 010111 |V| | vcompress   | 010111 | |F| vfmerge/vfmv
 | 011000 |V|X|I| vmseq      | 011000 |V| | vmandn      | 011000 |V|F| vmfeq
@@ -99,7 +99,7 @@ Vector instructions with *Zvkb (in bold)*
 | 110110 | | | |            | 110110 |V|X| vwsubu.w    | 110110 |V|F| vfwsub.w
 | 110111 | | | |            | 110111 |V|X| vwsub.w     | 110111 | | |
 | 111000 | | | |            | 111000 |V|X| vwmulu      | 111000 |V|F| vfwmul
-| 111001 | | | |            | 111001 | | |             | 111001 | | |      
+| 111001 | | | |            | 111001 | | |             | 111001 | | |
 | 111010 | | | |            | 111010 |V|X| vwmulsu     | 111010 | | |
 | 111011 | | | |            | 111011 |V|X| vwmul       | 111011 | | |
 | 111100 | | | |            | 111100 |V|X| vwmaccu     | 111100 |V|F| vfwmacc


### PR DESCRIPTION
@kdockser , as discussed today during the TG meeting: update of the opcodes with the current version of `funct6` / `funct5` field values.