### PR TITLE
Fixing size of upper most opcode fields for vror.vi (6 -> 5)

### DIFF
--- a/doc/vector/insns/vror.adoc
+++ b/doc/vector/insns/vror.adoc
@@ -56,7 +56,7 @@ Encoding (Vector-Immediate)::
 {bits: 5, name: 'vs2'},
 {bits: 1, name: 'vm'},
 {bits: 1, name: 'i5'},
-{bits: 6, name: '01010'},
+{bits: 5, name: '01010'},
 ]}
 ....
 


### PR DESCRIPTION
Signed-off-by: Nicolas Brunie <82109999+nibrunieAtSi5@users.noreply.github.com>