### PR TITLE
Add additional dependencies for Ubuntu 22.04

### DIFF
--- a/dependencies/apt_packages.txt
+++ b/dependencies/apt_packages.txt
@@ -13,6 +13,8 @@ libffi-dev
 libgdk-pixbuf2.0-dev
 libpango1.0-dev
 libxml2-dev
+libwebp-dev
+libzstd-dev
 make
 pkg-config
 ruby


### PR DESCRIPTION
Fix gem install asciidoctor-mathematical failure due to failure to build mathematical gem due to missing libwebp.

Signed-off-by: Jeff Scheel <jeff@riscv.org>