### PR TITLE
Suggesting non-overlap source/destination constraints for vsha2ms/vsha2c/vsm3me/vsm3c

### DIFF
--- a/doc/vector/insns/vsha2c.adoc
+++ b/doc/vector/insns/vsha2c.adoc
@@ -88,7 +88,7 @@ VLMUL must be at least 1. In typical usage it is expected to be 1.
 There are three source operands: vd, vs1 and vs2. The result
 is written to vd.
 
-These instructions take in two SEW words _W1_ and _W0_ which are next two words of the message 
+These instructions take in two SEW words _W1_ and _W0_ which are next two words of the message
 schedule after they have been incremented by the appropriate constant (see
 link:https://doi.org/10.6028/NIST.FIPS.180-4[FIPS PUB 180-4 Secure Hash Standard (SHS)])
 and eight SEW word variables: _a_, _b_, _c_, _d_, _e_, _f_, _g,_ and _h_. The
@@ -105,6 +105,14 @@ the input and the output, this would require code to copy the *Vd* register befo
 executing one of these instructions so that would be available as input to the next
 instruction for the input of _c_, _d_, _g_, and _h_. This would use up one more
 vector register and require one more instruction, without any benefit.
+
+
+The case where the `vd` register group overlap with either `vs1` or `vs2` is _reserved_.
+
+[NOTE]
+====
+Preventing overlap between `vd` and `vs1` or `vs2` simplifies implementation with `VLEN < EGW`.
+====
 
 [NOTE]
 ====

--- a/doc/vector/insns/vsha2ms.adoc
+++ b/doc/vector/insns/vsha2ms.adoc
@@ -94,11 +94,11 @@ The number of words to be processed is `vl`/`EGS`.
 therefore must be a multiple of `EGS=4`. +
 Likewise, `vstart` must be a multiple of `EGS=4`
 
-The case where the `vd` register group overlap with either `vs1` or `vs2` is reserved.
+The case where the `vd` register group overlap with either `vs1` or `vs2` is _reserved_.
 
 [NOTE]
 ====
-Preventing overlap between `vd` and `vs1` or `vs2` simplifies implementation with `VLEN < EGW`` while not impacting larger VLEN since it does not make sense to reuse a register group for different message schedule indices.
+Preventing overlap between `vd` and `vs1` or `vs2` simplifies implementation with `VLEN < EGW` while not impacting larger VLEN since it does not make sense to reuse a register group for different message schedule indices.
 ====
 
 

--- a/doc/vector/insns/vsm3c.adoc
+++ b/doc/vector/insns/vsm3c.adoc
@@ -84,6 +84,13 @@ The number of element groups to be processed is `vl`/`EGS`.
 therefore must be a multiple of `EGS=4`. +
 Likewise, `vstart` must be a multiple of `EGS=4`.
 
+The case where the `vd` register group overlap with `vs2` is _reserved_.
+
+[NOTE]
+====
+Preventing overlap between `vd` and `vs2` simplifies implementation with `VLEN < EGW` while not impacting larger VLEN since it does not make sense to reuse a register group for both message words and current state.
+====
+
 Operation::
 [source,sail]
 --

--- a/doc/vector/insns/vsm3me.adoc
+++ b/doc/vector/insns/vsm3me.adoc
@@ -64,6 +64,14 @@ The number of element groups to be processed is `vl`/`EGS`.
 therefore must be a multiple of `EGS=4`. +
 Likewise, `vstart` must be a multiple of `EGS=4`.
 
+The case where the `vd` register group overlap with `vs2` is _reserved_.
+
+[NOTE]
+====
+Preventing overlap between `vd` and `vs2` simplifies implementation with `VLEN < EGW`.
+Overlap between `vs1` and `vd` is not reserved as it could be useful for larger VLEN implementation while not impacting smaller VLEN.
+====
+
 Operation::
 [source,sail]
 --


### PR DESCRIPTION
Related to issue #254  

I am making this suggestion to facilitate the life of implementation with `VLEN < EGW` for the instructions with a large `EGW`.
These non-overlapping constraints should not impact performance of larger `VLEN` while making smaller `VLEN` implementation easier.