### PR TITLE
Update apt_packages.txt

### DIFF
--- a/dependencies/apt_packages.txt
+++ b/dependencies/apt_packages.txt
@@ -10,6 +10,7 @@ graphviz
 default-jre
 libcairo2-dev
 libffi-dev
+libgif-dev
 libgdk-pixbuf2.0-dev
 libpango1.0-dev
 libxml2-dev


### PR DESCRIPTION
Add libgif-dev as a new dependency to be installed on Ubuntu 22.04

Signed-off-by: Rafael Sene <rafael@riscv.org>