### PR TITLE
asciidoc: fix formatting errors

### DIFF
--- a/doc/vector/insns/vaesef.adoc
+++ b/doc/vector/insns/vaesef.adoc
@@ -57,7 +57,6 @@ Arguments::
 |===
 
 Description:: 
-....
 This instruction performs the final-round encryption function of the AES block cipher.
 
 In the case of the `.vs` form of the instruction, element group 0 of the single register `vs2` holds a

--- a/doc/vector/insns/vaeskf1.adoc
+++ b/doc/vector/insns/vaeskf1.adoc
@@ -41,7 +41,6 @@ Arguments::
 |===
 
 Description:: 
-....
 This instruction performs a single round of the forward AES-128 KeySchedule.
 
 The inputs and outputs to this instruction are comprised of 128-bit element groups.

--- a/doc/vector/insns/vaeskf2.adoc
+++ b/doc/vector/insns/vaeskf2.adoc
@@ -42,7 +42,6 @@ Arguments::
 |===
 
 Description:: 
-....
 This instruction performs a single round of the forward AES-256 KeySchedule.
 
 The inputs and outputs to this instruction are comprised of 128-bit element groups.


### PR DESCRIPTION
Yesterday's changes broke the PDF generation.
This addresses the formatting issues.