### PR TITLE
fixing bad indent for vaesdm description

### DIFF
--- a/doc/vector/insns/vaesdm.adoc
+++ b/doc/vector/insns/vaesdm.adoc
@@ -57,7 +57,6 @@ Arguments::
 |===
 
 Description::
-....
 This instruction performs the middle-round decryption function of the AES block cipher.
 
 In the case of the `.vs` form of the instruction, element group 0 of the single register `vs2` holds a
@@ -82,7 +81,6 @@ The number of element groups to be processed is `vl`/`EGS`.
 `vl` must be set to the number of `SEW=32` elements to be processed and 
 therefore must be a multiple of `EGS=4`. + 
 Likewise, `vstart` must be a multiple of `EGS=4`.
-....
 
 Operation::
 [source,sail]


### PR DESCRIPTION
The full description was appearing in a code block:

![image](https://user-images.githubusercontent.com/82109999/212574642-57829836-1c8e-4a71-bbe3-fb2954df18ef.png)


Signed-off-by: Nicolas Brunie <82109999+nibrunieAtSi5@users.noreply.github.com>