### PR TITLE
[minor changes] cleanup and clarifications

### DIFF
--- a/doc/vector/insns/vaesz.adoc
+++ b/doc/vector/insns/vaesz.adoc
@@ -62,7 +62,7 @@ step to the corresponding inputs.
 This instruction is needed to avoid the need to "splat" a 128-bit vector register group when the round key is the same for
 all 128-bit "lanes". Such a splat would typically be implemented with a `vrgather` instruction which would hurt performance
 in many implementations. 
-This instruction only exists in the `.vs` form because the `.vv` form would be identical to the VXOR instruction.
+This instruction only exists in the `.vs` form because the `.vv` form would be identical to the `vxor.vv vd, vs2, vd` instruction.
 ====
 
 This instruction operates on element groups in the source and destination registers.

--- a/doc/vector/insns/vghmac.adoc
+++ b/doc/vector/insns/vghmac.adoc
@@ -132,7 +132,7 @@ function clause execute (VGHMAC(vs2, vs1, vd)) = {
     let X = get_velem(vs2,EGW=128,i);       // next block cipher output
     let Z : bits(128) = 0;
 
-for (int bit = 0; bit < 128; bit++) {
+    for (int bit = 0; bit < 128; bit++) {
       if bit_to_bool(Y[bit])
         Z ^= H
 


### PR DESCRIPTION
- unifying instruction syntax in `vaesz.vs`
- pseudo-code indent for `vghmac`
Signed-off-by: Nicolas Brunie <82109999+nibrunieAtSi5@users.noreply.github.com>