### PR TITLE
Unifying operand syntax

### DIFF
--- a/doc/vector/insns/vandn.adoc
+++ b/doc/vector/insns/vandn.adoc
@@ -69,9 +69,9 @@ Description::
 A bitwise _and-not_ operation is performed.
 
 Each bit of `Op1` is inverted and logically ANDed with the corresponding bits in `Vs2`.
-In the vector-scalar version, Op1 is the sign-extended or truncated value in scalar
+In the vector-scalar version, `Op1` is the sign-extended or truncated value in scalar
 register `rs1`. 
-In the vector-vector version, Op1 is `vs2`.
+In the vector-vector version, `Op1` is `vs2`.
 
 This instruction must always be implemented such that its execution latency does not depend
 on the data being operated upon.

--- a/doc/vector/insns/vandn.adoc
+++ b/doc/vector/insns/vandn.adoc
@@ -68,7 +68,7 @@ Vector-Scalar Arguments::
 Description:: 
 A bitwise _and-not_ operation is performed.
 
-Each bit of `Op1` is inverted and logically ANDed with the corresponding bits in `Vs2`.
+Each bit of `Op1` is inverted and logically ANDed with the corresponding bits in `vs2`.
 In the vector-scalar version, `Op1` is the sign-extended or truncated value in scalar
 register `rs1`. 
 In the vector-vector version, `Op1` is `vs2`.


### PR DESCRIPTION
Signed-off-by: Nicolas Brunie <82109999+nibrunieAtSi5@users.noreply.github.com>

Another question, in the pseudo-code the bitwise inversion operator was changed from `~` to `!`, is it the right way to implement this in SAIL ?