### PR TITLE
vector: insns: vgmul: Remote vs1 from mnemonic

### DIFF
--- a/doc/vector/insns/vgmul.adoc
+++ b/doc/vector/insns/vgmul.adoc
@@ -5,7 +5,7 @@ Synopsis::
 Vector Multiply over GHASH Galois-Field
 
 Mnemonic::
-vgmul.vv vd, vs2, vs1
+vgmul.vv vd, vs2
 
 Encoding::
 [wavedrom, , svg]


### PR DESCRIPTION
vgmul.vv has only two operands.
Let's eliminate the "vs1" from the mnemonic.