### PR TITLE
Update riscv-crypto-vector-zvkt.adoc

### DIFF
--- a/doc/vector/riscv-crypto-vector-zvkt.adoc
+++ b/doc/vector/riscv-crypto-vector-zvkt.adoc
@@ -38,7 +38,7 @@ The values in `vs1` are used for control and are exempt from DIEL.
 - vrgather.vv
 - vrgatherei16.vv
 
-=== All othe instructions (to be grouped)
+=== All other instructions (to be grouped)
 
 === Add
 - vadd	vi	Add

--- a/doc/vector/riscv-crypto-vector-zvkt.adoc
+++ b/doc/vector/riscv-crypto-vector-zvkt.adoc
@@ -26,7 +26,7 @@ latency of the instruction. Sometime such elements contain data that also needs 
 - vandn.v[vx]
 
 ==== The `vslideup` and `vslidedown` Instructions
-The in `rs1` and `uimm` are used to specify the slide amount and are exempt from DIEL.
+The values in `rs1` and `uimm` are used to specify the slide amount and are exempt from DIEL.
 
 - vslideup.v[xi]
 - vslidedown.v[xi]

--- a/doc/vector/riscv-crypto-vector-zvkt.adoc
+++ b/doc/vector/riscv-crypto-vector-zvkt.adoc
@@ -6,7 +6,7 @@ executed with data-independent execution latency as defined in the
 link:https://github.com/riscv/riscv-crypto/releases/tag/v1.0.1-scalar[RISC-V Scalar Cryptography Extensions specification].
 
 The data-independent execution latency (DIEL) applies to all _data operands_ of an instruction, even those that are not a
-part of the body or that are inactove. However, DIEL does not apply to other values such as vl, vtype, and the mask.
+part of the body or that are inactive. However, DIEL does not apply to other values such as vl, vtype, and the mask.
 In some cases --- which are explicitly specified in the lists below --- operands that are used as control rather than data
 and are exempt from DIEL.
 


### PR DESCRIPTION
Fixing typo reported by @kdockser during Feb 23rd TG meeting