### PR TITLE
Fix retirement on illegal instructions

### DIFF
--- a/doc/vector/insns/vaesdf.adoc
+++ b/doc/vector/insns/vaesdf.adoc
@@ -74,7 +74,7 @@ Operation::
 function clause execute (VAESDF(vs2, vd, suffix)) = {
   if(((vstart%EGS)<>0) | (LMUL*VLEN < EGW))  then {
     handle_illegal();  // illegal instruction exception
-    RETIRE_SUCCESS
+    RETIRE_FAIL
   } else {
 
   eg_len = (vl/EGS)

--- a/doc/vector/insns/vaesdm.adoc
+++ b/doc/vector/insns/vaesdm.adoc
@@ -78,7 +78,7 @@ Operation::
 function clause execute (VAESDM(vs2, vd, suffix)) = {
   if(((vstart%EGS)<>0) | (LMUL*VLEN < EGW))  then {
     handle_illegal();  // illegal instruction exception
-    RETIRE_SUCCESS
+    RETIRE_FAIL
   } else {
 
   eg_len = (vl/EGS)

--- a/doc/vector/insns/vaesef.adoc
+++ b/doc/vector/insns/vaesef.adoc
@@ -78,7 +78,7 @@ Operation::
 function clause execute (VAESEF(vs2, vd, suffix) = {
   if(((vstart%EGS)<>0) | (LMUL*VLEN < EGW))  then {
     handle_illegal();  // illegal instruction exception
-    RETIRE_SUCCESS
+    RETIRE_FAIL
   } else {
 
   eg_len = (vl/EGS)

--- a/doc/vector/insns/vaesem.adoc
+++ b/doc/vector/insns/vaesem.adoc
@@ -78,7 +78,7 @@ Operation::
 function clause execute (VAESEM(vs2, vd, suffix)) = {
   if(((vstart%EGS)<>0) | (LMUL*VLEN < EGW))  then {
     handle_illegal();  // illegal instruction exception
-    RETIRE_SUCCESS
+    RETIRE_FAIL
   } else {
 
   eg_len = (vl/EGS)

--- a/doc/vector/insns/vaeskf1.adoc
+++ b/doc/vector/insns/vaeskf1.adoc
@@ -83,7 +83,7 @@ Operation::
 function clause execute (VAESESKF1(rnd, vd, vs2)) = {
   if(((vstart%EGS)<>0) | (LMUL*VLEN < EGW))  then {
     handle_illegal();  // illegal instruction exception
-    RETIRE_SUCCESS
+    RETIRE_FAIL
   } else {
 
  // project out-of-range immediates onto in-range values

--- a/doc/vector/insns/vaeskf2.adoc
+++ b/doc/vector/insns/vaeskf2.adoc
@@ -79,7 +79,7 @@ Operation::
 function clause execute (VAESESKF2(rnd, vd, vs2)) = {
   if(((vstart%EGS)<>0) | (LMUL*VLEN < EGW))  then {
     handle_illegal();  // illegal instruction exception
-    RETIRE_SUCCESS
+    RETIRE_FAIL
   } else {
 
  // project out-of-range immediates into in-range values

--- a/doc/vector/insns/vaesz.adoc
+++ b/doc/vector/insns/vaesz.adoc
@@ -74,7 +74,7 @@ Operation::
 function clause execute (VAESZ(vs2, vd) = {
   if(((vstart%EGS)<>0) | (LMUL*VLEN < EGW))  then {
     handle_illegal();  // illegal instruction exception
-    RETIRE_SUCCESS
+    RETIRE_FAIL
   } else {
 
   eg_len = (vl/EGS)

--- a/doc/vector/insns/vghsh.adoc
+++ b/doc/vector/insns/vghsh.adoc
@@ -81,7 +81,7 @@ function clause execute (VGHSH(vs2, vs1, vd)) = {
   // operands are input with bits reversed in each byte
   if(((vstart%EGS)<>0) | (LMUL*VLEN < EGW))  then {
     handle_illegal();  // illegal instruction exception
-    RETIRE_SUCCESS
+    RETIRE_FAIL
   } else {
 
   eg_len = (vl/EGS)

--- a/doc/vector/insns/vgmul.adoc
+++ b/doc/vector/insns/vgmul.adoc
@@ -84,7 +84,7 @@ function clause execute (VGMUL(vs2, vs1, vd)) = {
   // operands are input with bits reversed in each byte
   if(((vstart%EGS)<>0) | (LMUL*VLEN < EGW))  then {
     handle_illegal();  // illegal instruction exception
-    RETIRE_SUCCESS
+    RETIRE_FAIL
   } else {
 
   eg_len = (vl/EGS)

--- a/doc/vector/insns/vsha2c.adoc
+++ b/doc/vector/insns/vsha2c.adoc
@@ -143,7 +143,7 @@ Operation::
 function clause execute (VSHA2c(vs2, vs1, vd)) = {
   if(((vstart%EGS)<>0) | (LMUL*VLEN < EGW))  then {
     handle_illegal();  // illegal instruction exception
-    RETIRE_SUCCESS
+    RETIRE_FAIL
   } else {
 
   eg_len = (vl/EGS)

--- a/doc/vector/insns/vsha2ms.adoc
+++ b/doc/vector/insns/vsha2ms.adoc
@@ -137,7 +137,7 @@ function clause execute (VSHA2ms(vs2, vs1, vd)) = {
   // SEW64 =  SHA-512
   if(((vstart%EGS)<>0) | (LMUL*VLEN < EGW))  then {
     handle_illegal();  // illegal instruction exception
-    RETIRE_SUCCESS
+    RETIRE_FAIL
   } else {
 
   eg_len = (vl/EGS)

--- a/doc/vector/insns/vsm3c.adoc
+++ b/doc/vector/insns/vsm3c.adoc
@@ -101,7 +101,7 @@ Operation::
 function clause execute (VSM3C(rnds, vs2, vd)) = {
   if(((vstart%EGS)<>0) | (LMUL*VLEN < EGW))  then {
     handle_illegal();  // illegal instruction exception
-    RETIRE_SUCCESS
+    RETIRE_FAIL
   } else {
 
   eg_len = (vl/EGS)

--- a/doc/vector/insns/vsm3me.adoc
+++ b/doc/vector/insns/vsm3me.adoc
@@ -83,7 +83,7 @@ Operation::
 function clause execute (VSM3ME(vs2, vs1)) = {
   if(((vstart%EGS)<>0) | (LMUL*VLEN < EGW))  then {
     handle_illegal();  // illegal instruction exception
-    RETIRE_SUCCESS
+    RETIRE_FAIL
   } else {
 
   eg_len = (vl/EGS)

--- a/doc/vector/insns/vsm4k.adoc
+++ b/doc/vector/insns/vsm4k.adoc
@@ -151,7 +151,7 @@ Operation::
 function clause execute (vsm4k(uimm, vs2)) = {
   if(((vstart%EGS)<>0) | (LMUL*VLEN < EGW))  then {
     handle_illegal();  // illegal instruction exception
-    RETIRE_SUCCESS
+    RETIRE_FAIL
   } else {
 
   eg_len = (vl/EGS)

--- a/doc/vector/insns/vsm4r.adoc
+++ b/doc/vector/insns/vsm4r.adoc
@@ -93,7 +93,7 @@ Operation::
 function clause execute (VSM4R(vd, vs2)) = {
   if(((vstart%EGS)<>0) | (LMUL*VLEN < EGW))  then {
     handle_illegal();  // illegal instruction exception
-    RETIRE_SUCCESS
+    RETIRE_FAIL
   } else {
 
   eg_len = (vl/EGS)


### PR DESCRIPTION
In the **OPERATION**(SAIL code) section of each instruction the code states that we should exit successfully when we have an illegal instruction exception, which is wrong. We should retire as fail(`RETIRE_FAIL`) instead of `RETIRE_SUCCESS`.