### PR TITLE
Suggesting vclz behaviour fix

### DIFF
--- a/doc/vector/insns/vclz.adoc
+++ b/doc/vector/insns/vclz.adoc
@@ -48,8 +48,7 @@ function clause execute (VCLZ(vs2)) = {
     let input = get_velem(vs2, SEW, i);
     for (j = (SEW - 1); j >= 0;  j--)
       if [input[j]] == 0b1 then break;
-    if (j==-1) then j = SEW;
-    set_velem(vd, SEW, i, j)
+    set_velem(vd, SEW, i, SEW - 1 - j)
   }
   RETIRE_SUCCESS
 }


### PR DESCRIPTION
I think we need a different expression for the leading zero count:
- if `input[SEW-1] == 1` we must return 0 
- if `input[0] == 1` we must return SEW-1