### PR TITLE
vector-crypto: Reset vstart CSR to zero at the end of execution

### DIFF
--- a/doc/vector/insns/vaesdf.adoc
+++ b/doc/vector/insns/vaesdf.adoc
@@ -89,6 +89,7 @@ function clause execute (VAESDF(vs2, vd, suffix)) = {
     let ark   : bits(128) = sb ^ rkey;
     set_velem(vd, EGW=128, i, ark);
   }
+  vstart = 0
   RETIRE_SUCCESS
   }
 }

--- a/doc/vector/insns/vaesdm.adoc
+++ b/doc/vector/insns/vaesdm.adoc
@@ -94,6 +94,7 @@ function clause execute (VAESDM(vs2, vd, suffix)) = {
     let mix   : bits(128) = aes_mixcolumns_inv(ark);
     set_velem(vd, EGW=128, i, mix);
   }
+  vstart = 0
   RETIRE_SUCCESS
   }
 }

--- a/doc/vector/insns/vaesef.adoc
+++ b/doc/vector/insns/vaesef.adoc
@@ -93,6 +93,7 @@ function clause execute (VAESEF(vs2, vd, suffix) = {
     let ark   : bits(128) = sr ^ rkey;
     set_velem(vd, EGW=128, i, ark);
   }
+  vstart = 0
   RETIRE_SUCCESS
   }
 }

--- a/doc/vector/insns/vaesem.adoc
+++ b/doc/vector/insns/vaesem.adoc
@@ -94,6 +94,7 @@ function clause execute (VAESEM(vs2, vd, suffix)) = {
     let ark   : bits(128) = mix ^ rkey;
     set_velem(vd, EGW=128, i, ark);
   }
+  vstart = 0
   RETIRE_SUCCESS
   }
 }

--- a/doc/vector/insns/vaeskf1.adoc
+++ b/doc/vector/insns/vaeskf1.adoc
@@ -103,6 +103,7 @@ function clause execute (VAESESKF1(rnd, vd, vs2)) = {
       let w[3] : bits(32) = w[2] XOR CurrentRoundKey[3]
       set_velem(vd, EGW=128, i, w[3:0]);
     }
+    vstart = 0
     RETIRE_SUCCESS
   }
 }

--- a/doc/vector/insns/vaeskf2.adoc
+++ b/doc/vector/insns/vaeskf2.adoc
@@ -101,6 +101,7 @@ function clause execute (VAESESKF2(rnd, vd, vs2)) = {
       w[3] : bits(32) = w[2] XOR RoundKeyB[3]
       set_velem(vd, EGW=128, i, w[3:0]);
     }
+    vstart = 0
     RETIRE_SUCCESS
   }
 }

--- a/doc/vector/insns/vaesz.adoc
+++ b/doc/vector/insns/vaesz.adoc
@@ -86,6 +86,7 @@ function clause execute (VAESZ(vs2, vd) = {
     let ark   : bits(128) = state ^ rkey;
     set_velem(vd, EGW=128, i, ark);
   }
+  vstart = 0
   RETIRE_SUCCESS
   }
 }

--- a/doc/vector/insns/vandn.adoc
+++ b/doc/vector/insns/vandn.adoc
@@ -101,6 +101,7 @@ function clause execute (VANDN(vs2, vs1, vd, suffix)) = {
     let op2 = get_velem(vs2, SEW, i);
     set_velem(vd, EEW=SEW, i, ~op1 & op2);
   }
+  vstart = 0
   RETIRE_SUCCESS
 }
 

--- a/doc/vector/insns/vbrev.adoc
+++ b/doc/vector/insns/vbrev.adoc
@@ -49,6 +49,7 @@ function clause execute (VBREV(vs2)) = {
       let output[SEW-1-i] = input[i];
     set_velem(vd, SEW, i, output)
   }
+  vstart = 0
   RETIRE_SUCCESS
 }
 --

--- a/doc/vector/insns/vbrev8.adoc
+++ b/doc/vector/insns/vbrev8.adoc
@@ -58,6 +58,7 @@ function clause execute (VBREV8(vs2)) = {
       let output[i+7..i] = reverse_bits_in_byte(input[i+7..i]);
     set_velem(vd, SEW, i, output)
   }
+  vstart = 0
   RETIRE_SUCCESS
 }
 --

--- a/doc/vector/insns/vclmul.adoc
+++ b/doc/vector/insns/vclmul.adoc
@@ -87,6 +87,7 @@ function clause execute (VCLMUL(vs2, vs1, vd, suffix)) = {
     let product : bits (64) = clmul(op1,op2,SEW);
     set_velem(vd, i, product);
   }
+  vstart = 0
   RETIRE_SUCCESS
 }
 

--- a/doc/vector/insns/vclmulh.adoc
+++ b/doc/vector/insns/vclmulh.adoc
@@ -74,6 +74,7 @@ function clause execute (VCLMULH(vs2, vs1, vd, suffix)) = {
     let product : bits (64) = clmulh(op1, op2, SEW);
     set_velem(vd, i, product);
   }
+  vstart = 0
   RETIRE_SUCCESS
 }
 

--- a/doc/vector/insns/vclz.adoc
+++ b/doc/vector/insns/vclz.adoc
@@ -50,6 +50,7 @@ function clause execute (VCLZ(vs2)) = {
       if [input[j]] == 0b1 then break;
     set_velem(vd, SEW, i, SEW - 1 - j)
   }
+  vstart = 0
   RETIRE_SUCCESS
 }
 --

--- a/doc/vector/insns/vcpop.adoc
+++ b/doc/vector/insns/vcpop.adoc
@@ -49,6 +49,7 @@ function clause execute (VCPOP(vs2)) = {
       output = output + input[j];
     set_velem(vd, SEW, i, output)
   }
+  vstart = 0
   RETIRE_SUCCESS
 }
 --

--- a/doc/vector/insns/vctz.adoc
+++ b/doc/vector/insns/vctz.adoc
@@ -50,6 +50,7 @@ function clause execute (VCTZ(vs2)) = {
       if [input[j]] == 0b1 then break;
     set_velem(vd, SEW, i, j)
   }
+  vstart = 0
   RETIRE_SUCCESS
 }
 --

--- a/doc/vector/insns/vghsh.adoc
+++ b/doc/vector/insns/vghsh.adoc
@@ -109,6 +109,7 @@ function clause execute (VGHSH(vs2, vs1, vd)) = {
     let result = brev8(Z); // bit reverse bytes to get back to GCM standard ordering
     set_velem(vd, EGW=128, i, result);
   }
+  vstart = 0
   RETIRE_SUCCESS
  }
 }

--- a/doc/vector/insns/vgmul.adoc
+++ b/doc/vector/insns/vgmul.adoc
@@ -109,6 +109,7 @@ function clause execute (VGMUL(vs2, vs1, vd)) = {
     let result = brev8(Z); 
     set_velem(vd, EGW=128, i, result);
   }
+  vstart = 0
   RETIRE_SUCCESS
  }
 }

--- a/doc/vector/insns/vrev8.adoc
+++ b/doc/vector/insns/vrev8.adoc
@@ -58,6 +58,7 @@ function clause execute (VREV8(vs2)) = {
       j = j - 8;
     set_velem(vd, SEW, i, output)
   }
+  vstart = 0
   RETIRE_SUCCESS
 }
 --

--- a/doc/vector/insns/vrol.adoc
+++ b/doc/vector/insns/vrol.adoc
@@ -91,6 +91,7 @@ function clause execute (VROL_VV(vs2, vs1, vd)) = {
       get_velem(vs2, i) <<< (get_velem(vs1, i) & (SEW-1))
     )
   }
+  vstart = 0
   RETIRE_SUCCESS
 }
 
@@ -100,6 +101,7 @@ function clause execute (VROL_VX(vs2, rs1, vd)) = {
       get_velem(vs2, i) <<< (X(rs1) & (SEW-1))
     )
   }
+  vstart = 0
   RETIRE_SUCCESS
 }
 

--- a/doc/vector/insns/vror.adoc
+++ b/doc/vector/insns/vror.adoc
@@ -102,6 +102,7 @@ function clause execute (VROR_VV(vs2, vs1, vd)) = {
       get_velem(vs2, i) >>> (get_velem(vs1, i) & (SEW-1))
     )
   }
+  vstart = 0
   RETIRE_SUCCESS
 }
 
@@ -111,6 +112,7 @@ function clause execute (VROR_VX(vs2, rs1, vd)) = {
       get_velem(vs2, i) >>> (X(rs1) & (SEW-1))
     )
   }
+  vstart = 0
   RETIRE_SUCCESS
 }
 
@@ -120,6 +122,7 @@ function clause execute (VROR_VI(vs2, imm[5:0], vd)) = {
       get_velem(vs2, i) >>> (imm[5:0] & (SEW-1))
     )
   }
+  vstart = 0
   RETIRE_SUCCESS
 }
 --

--- a/doc/vector/insns/vsha2c.adoc
+++ b/doc/vector/insns/vsha2c.adoc
@@ -179,6 +179,7 @@ function clause execute (VSHA2c(vs2, vs1, vd)) = {
 	  a = T1 + T2;
 	  set_velem(vd, 4*SEW, i, {a @ b @ e @ f});
   }
+  vstart = 0
   RETIRE_SUCCESS
   }
 }

--- a/doc/vector/insns/vsha2ms.adoc
+++ b/doc/vector/insns/vsha2ms.adoc
@@ -155,6 +155,7 @@ function clause execute (VSHA2ms(vs2, vs1, vd)) = {
 
     set_velem(vd, EGW, i, {W[19] @ W[18] @ W[17] @ W[16]});
   }
+  vstart = 0
   RETIRE_SUCCESS
   }
 }

--- a/doc/vector/insns/vsm3c.adoc
+++ b/doc/vector/insns/vsm3c.adoc
@@ -166,6 +166,7 @@ let result : bits(256) = {rev8(G1) @ rev8(G2) @ rev8(E1) @ rev8(E2) @ rev8(C1) @
 set_velem(vd, 256, i, result);
       }
 
+vstart = 0
 RETIRE_SUCCESS
   }
 }

--- a/doc/vector/insns/vsm3me.adoc
+++ b/doc/vector/insns/vsm3me.adoc
@@ -135,6 +135,7 @@ function clause execute (VSM3ME(vs2, vs1)) = {
     // Update the destination register.
     set_velem(vd, 256, i, {w23 @ w22 @ w21 @ w20 @ w19 @ w18 @ w17 @ w16});
   }
+  vstart = 0
   RETIRE_SUCCESS
   }
 }

--- a/doc/vector/insns/vsm4k.adoc
+++ b/doc/vector/insns/vsm4k.adoc
@@ -187,6 +187,7 @@ function clause execute (vsm4k(uimm, vs2)) = {
     // Update the destination register.
    set_velem(vd, EGW=128, i, (rk7 @ rk6 @ rk5 @ rk4));
   }
+  vstart = 0
   RETIRE_SUCCESS
   }
 }

--- a/doc/vector/insns/vsm4r.adoc
+++ b/doc/vector/insns/vsm4r.adoc
@@ -140,6 +140,7 @@ function clause execute (VSM4R(vd, vs2)) = {
     set_velem(vd, EGW=128, i, (x7 @ x6 @ x5 @ x4));
 
   }
+  vstart = 0
   RETIRE_SUCCESS
   }
 }

--- a/doc/vector/insns/vwsll.adoc
+++ b/doc/vector/insns/vwsll.adoc
@@ -99,6 +99,7 @@ function clause execute (VWSLL_VV(vs2, vs1, vd)) = {
       get_velem(vs2, i) << (get_velem(vs1, i) & (SEW-1))
     )
   }
+  vstart = 0
   RETIRE_SUCCESS
 }
 
@@ -108,6 +109,7 @@ function clause execute (VWSLL_VX(vs2, rs1, vd)) = {
       get_velem(vs2, i) << (X(rs1) & (SEW-1))
     )
   }
+  vstart = 0
   RETIRE_SUCCESS
 }
 
@@ -117,6 +119,7 @@ function clause execute (VWSLL_VI(vs2, uimm[4:0], vd)) = {
       get_velem(vs2, i) << (imm[4:0] & (SEW-1))
     )
   }
+  vstart = 0
   RETIRE_SUCCESS
 }
 --

--- a/doc/vector/riscv-crypto-vector-instruction-constraints.adoc
+++ b/doc/vector/riscv-crypto-vector-instruction-constraints.adoc
@@ -92,3 +92,6 @@ overlap this `vs2` register group.
 
 |===
 
+vstart reset constraints::
+All vector instructions are defined to begin execution with the element number given in the vstart CSR,
+leaving earlier elements in the destination vector undisturbed, and to reset the vstart CSR to zero at the end of execution.


### PR DESCRIPTION
The vector crypto instructions use the vstart CSR as intended by the vector specification. However, the instructions should also reset the vstart CSR after (successful) execution.

Let's add this behaviour to the instruction constrains section, which also specifies the use of the vstart CSR.
Further, let's update all instruction descriptions to clear the vstart CSR after execution.

CC @kdockser