### PR TITLE
Update function names and fix element width references

### DIFF
--- a/doc/vector/insns/vaesem.adoc
+++ b/doc/vector/insns/vaesem.adoc
@@ -90,7 +90,7 @@ function clause execute (VAESEM(vs2, vd, suffix)) = {
     let rkey  : bits(128) = get_velem(vs2, EGW=128, keyelem);
     let sb    : bits(128) = aes_subbytes_fwd(state);
     let sr    : bits(128) = aes_shift_rows_fwd(sb);
-    let mix   : bits(128) = aes_fwd_mixcolumns_fwd(sr);
+    let mix   : bits(128) = aes_mixcolumns_fwd(sr);
     let ark   : bits(128) = mix ^ rkey;
     set_velem(vd, EGW=128, i, ark);
   }

--- a/doc/vector/insns/vaeskf1.adoc
+++ b/doc/vector/insns/vaeskf1.adoc
@@ -80,7 +80,7 @@ behavior to be fully defined for all values of `uimm[4:0]` with minimal extra lo
 Operation::
 [source,Sail]
 --
-function clause execute (VAESESKF1(rnd, vd, vs2)) = {
+function clause execute (VAESKF1(rnd, vd, vs2)) = {
   if(LMUL*VLEN < EGW)  then {
     handle_illegal();  // illegal instruction exception
     RETIRE_FAIL

--- a/doc/vector/insns/vaeskf2.adoc
+++ b/doc/vector/insns/vaeskf2.adoc
@@ -76,7 +76,7 @@ behavior to be fully defined for all values of `uimm[4:0]` with minimal extra lo
 Operation::
 [source,Sail]
 --
-function clause execute (VAESESKF2(rnd, vd, vs2)) = {
+function clause execute (VAESKF2(rnd, vd, vs2)) = {
   if(LMUL*VLEN < EGW)  then {
     handle_illegal();  // illegal instruction exception
     RETIRE_FAIL

--- a/doc/vector/insns/vsha2ms.adoc
+++ b/doc/vector/insns/vsha2ms.adoc
@@ -144,9 +144,9 @@ function clause execute (VSHA2ms(vs2, vs1, vd)) = {
   eg_start = (vstart/EGS)
 
   foreach (i from eg_start to eg_len-1) {
-    {W[3] @  W[2] @  W[1] @  W[0]}  : bits(EGW) = get_velem(vd, SEW, i);
-    {W[11] @ W[10] @ W[9] @  W[4]}  : bits(EGW) = get_velem(vs2, SEW, i);
-    {W[15] @ W[14] @ W[13] @ W[12]} : bits(EGW) = get_velem(vs1, SEW, i);
+    {W[3] @  W[2] @  W[1] @  W[0]}  : bits(EGW) = get_velem(vd, EGW, i);
+    {W[11] @ W[10] @ W[9] @  W[4]}  : bits(EGW) = get_velem(vs2, EGW, i);
+    {W[15] @ W[14] @ W[13] @ W[12]} : bits(EGW) = get_velem(vs1, EGW, i);
   
     W[16] = sig1(W[14]) + W[9]  + sig0(W[1]) + W[0];
     W[17] = sig1(W[15]) + W[10] + sig0(W[2]) + W[1];

--- a/doc/vector/riscv-crypto-vector-zvkn.adoc
+++ b/doc/vector/riscv-crypto-vector-zvkn.adoc
@@ -11,7 +11,7 @@ This extension is shorthand for the following set of other extensions:
 
 
 | Zvkned  | <<Zvkned>>
-| Zvknhb  | <<Zvknh>>
+| Zvknhb  | <<zvknh,Zvknhb>>
 | Zvbb    | <<Zvbb>>
 | Zvbc    | <<Zvbc>>
 | Zvkt    | <<Zvkt>>


### PR DESCRIPTION
- Rename aes_fwd_mixcolumns_fwd to aes_mixcolumns_fwd in vaesem.adoc
- Fix function names in vaeskf1.adoc and vaeskf2.adoc
- Update element width references in vsha2ms.adoc
- Fix broken reference in riscv-crypto-vector-zvkn.adoc