### PR TITLE
[code-samples] Fixing links to Rivos' repo

### DIFF
--- a/doc/vector/code-samples/README.md
+++ b/doc/vector/code-samples/README.md
@@ -94,5 +94,5 @@ References
 
 - [1] https://datatracker.ietf.org/doc/html/draft-oscca-cfrg-sm3-00
 - [2] https://datatracker.ietf.org/doc/html/draft-ribose-cfrg-sm4-10
-- [3] https://github.com/rivosinc/binutils-gdb/tree/vector-crypto
-- [4] https://github.com/rivosinc/riscv-isa-sim/tree/vector-crypto
+- [3] https://github.com/rivosinc/binutils-gdb/tree/zvk-vector-crypto
+- [4] https://github.com/rivosinc/riscv-isa-sim/tree/zvk-vector-crypto


### PR DESCRIPTION
links where not pointing to the correct branch

It would be good if eventually the code samples could be built from code in riscv official repos.