### PR TITLE
[#336] Fixing round constant indexing in vaeskf2 pseudo code

### DIFF
--- a/doc/vector/insns/vaeskf2.adoc
+++ b/doc/vector/insns/vaeskf2.adoc
@@ -95,7 +95,7 @@ function clause execute (VAESKF2(rnd, vd, vs2)) = {
       let w[0] : bits(32) = if (rnd[0]==1) then
         aes_subword_fwd(CurrentRoundKey[3]) XOR RoundKeyB[0]; 
       else
-        aes_subword_fwd(aes_rotword(CurrentRoundKey[3])) XOR aes_decode_rcon(rnd>>1) XOR RoundKeyB[0];
+        aes_subword_fwd(aes_rotword(CurrentRoundKey[3])) XOR aes_decode_rcon((rnd>>1) - 1) XOR RoundKeyB[0];
       w[1] : bits(32) = w[0] XOR RoundKeyB[1]
       w[2] : bits(32) = w[1] XOR RoundKeyB[2]
       w[3] : bits(32) = w[2] XOR RoundKeyB[3]


### PR DESCRIPTION
Fixing round constant indexing in `vaeskf2.vi` such that the range of round constants, [2, 14], is aligned with the AES constant as defined in the pseudo code helper `aes_decode_rcon` for AES-256 key schedule.