### PR TITLE
[Zvk Code Samples] Fix mask logic of GHASH-via-Zvbc

### DIFF
--- a/doc/vector/code-samples/zvb-ghash.s
+++ b/doc/vector/code-samples/zvb-ghash.s
@@ -46,7 +46,8 @@ zvb_ghash_init:
     li t1, 63
     la t2, polymod
 
-    vsetivli x0, 2, e64, m1, ta, ma
+    # Mask undisturbed for the vor/vxor.
+    vsetivli x0, 2, e64, m1, ta, mu
 
     vlse64.v v1, (a0), t0
     vle64.v v2, (t2)
@@ -106,7 +107,7 @@ zvb_ghash:
     add a0, a0, 8
     li t4, -8
 
-    vsetivli x0, 2, e64, m1, ta, ma
+    vsetivli x0, 2, e64, m1, ta, mu
 
     vlse64.v v5, (a0), t4
     vrev8.v v5, v5


### PR DESCRIPTION
As discovered by @shakakao and reported by @nibrunieAtSi5 (see https://github.com/riscv/riscv-crypto/issues/331), the Zvbc-based GHASH logic incorrectly relies on vxor to leave masked-off lanes undisturbed even though it sets the vector state with a mask agnostic policy.

The fix is to use ", mu" to request masked-off elements to be undisturbed.

I did check all proof-of-concept tests in an environment where masked-off elements get overwritten when "ma" is in effect. Prior to those fixes only the 'aes-gcm-test' fails, and all pass with those fixes.

Fixes: https://github.com/riscv/riscv-crypto/issues/331