### PR TITLE
Suggestion typo Remaindering -> remainder

### DIFF
--- a/doc/scalar/riscv-crypto-scalar-zkt.adoc
+++ b/doc/scalar/riscv-crypto-scalar-zkt.adoc
@@ -208,7 +208,7 @@ encoding forms of these instructions.
 
 ====	RVM (Multiply)
 
-Multiplication is included; division and remaindering excluded.
+Multiplication is included; division and remainder excluded.
 
 [%header,cols="^1,^1,4,8"]
 |===


### PR DESCRIPTION
Either this is a typo or am I going to learn a new world (non native speaker here so beware).