### PR TITLE
[Zkt] Remove c.addiw/c.subw/c.addw for RV32

### DIFF
--- a/doc/scalar/riscv-crypto-scalar-zkt.adoc
+++ b/doc/scalar/riscv-crypto-scalar-zkt.adoc
@@ -237,7 +237,7 @@ Same criteria as in RVI. Organised by quadrants.
 
 | &#10003; | &#10003; | c.nop      | <<insns-c_nop>>
 | &#10003; | &#10003; | c.addi     | <<insns-c_addi>>
-| &#10003; | &#10003; | c.addiw    | <<insns-c_addiw>>
+|          | &#10003; | c.addiw    | <<insns-c_addiw>>
 | &#10003; | &#10003; | c.lui      | <<insns-c_lui>>
 | &#10003; | &#10003; | c.srli     | <<insns-c_srli>>
 | &#10003; | &#10003; | c.srai     | <<insns-c_srai>>
@@ -246,8 +246,8 @@ Same criteria as in RVI. Organised by quadrants.
 | &#10003; | &#10003; | c.xor      | <<insns-c_xor>>
 | &#10003; | &#10003; | c.or       | <<insns-c_or>>
 | &#10003; | &#10003; | c.and      | <<insns-c_and>>
-| &#10003; | &#10003; | c.subw     | <<insns-c_subw>>
-| &#10003; | &#10003; | c.addw     | <<insns-c_addw>>
+|          | &#10003; | c.subw     | <<insns-c_subw>>
+|          | &#10003; | c.addw     | <<insns-c_addw>>
 | &#10003; | &#10003; | c.slli     | <<insns-c_slli>>
 | &#10003; | &#10003; | c.mv       | <<insns-c_mv>>
 | &#10003; | &#10003; | c.add      | <<insns-c_add>>


### PR DESCRIPTION
These instructions with postfix "w" don't exist in RV32.