### PR TITLE
Add rorw and rolw to the Zkt list

### DIFF
--- a/doc/scalar/riscv-crypto-scalar-zkt.adoc
+++ b/doc/scalar/riscv-crypto-scalar-zkt.adoc
@@ -324,6 +324,8 @@ specific instances of `grevi`, `shfli` and `unshfli` respectively.
 | &#10003; | &#10003; |  ror         | <<insns-ror>>
 | &#10003; | &#10003; |  rol         | <<insns-rol>>
 | &#10003; | &#10003; |  rori        | <<insns-rori>>
+|          | &#10003; |  rorw        | <<insns-rorw>>
+|          | &#10003; |  rolw        | <<insns-rolw>>
 |          | &#10003; |  roriw       | <<insns-roriw>>
 | &#10003; | &#10003; |  andn        | <<insns-andn>>
 | &#10003; | &#10003; |  orn         | <<insns-orn>>


### PR DESCRIPTION
The description says all of Zbkb is included, but these two instructions from Zbkb were not listed in the table.