### PR TITLE
Clarify that `Zkr` depends on `Zicsr`

### DIFF
--- a/doc/scalar/riscv-crypto-scalar-zkr.adoc
+++ b/doc/scalar/riscv-crypto-scalar-zkr.adoc
@@ -5,6 +5,8 @@ The entropy source extension defines the `seed` CSR at address `0x015`.
 This CSR provides up to 16 physical `entropy` bits that can be used to
 seed cryptographic random bit generators. 
 
+This extension depends on the `Zicsr` extension.
+
 See <<crypto_scalar_es>> for the normative specification and access control
 notes. <<crypto_scalar_appx_es>> contains design rationale and further
 recommendations to implementers.


### PR DESCRIPTION
As this extension defines its own CSR `seed`, it's more natural to have this sentence.

Resolves #350.