### PR TITLE
removing mention of inclusion in Zvknh from vaes* insns

### DIFF
--- a/doc/vector/insns/vaesdf.adoc
+++ b/doc/vector/insns/vaesdf.adoc
@@ -79,7 +79,7 @@ function clause execute (VAESDF(vs2, vd, suffix)) = {
 
   eg_len = (vl/EGS)
   eg_start = (vstart/EGS)
-  
+
   foreach (i from eg_start to eg_len-1) {
     let keyelem = if suffix == "vv" then i else 0;
     let state : bits(128) = get_velem(vd,  EGW=128, i);
@@ -95,4 +95,4 @@ function clause execute (VAESDF(vs2, vd, suffix)) = {
 --
 
 Included in::
-<<zvkn>>, <<zvknc>>, <<zvkned>>, <<zvkng>>, <<zvknh>>
+<<zvkn>>, <<zvknc>>, <<zvkned>>, <<zvkng>>

--- a/doc/vector/insns/vaesdm.adoc
+++ b/doc/vector/insns/vaesdm.adoc
@@ -68,8 +68,8 @@ This instruction must always be implemented such that its execution latency does
 on the data being operated upon.
 //
 // The number of element groups to be processed is `vl`/`EGS`.
-// `vl` must be set to the number of `SEW=32` elements to be processed and 
-// therefore must be a multiple of `EGS=4`. + 
+// `vl` must be set to the number of `SEW=32` elements to be processed and
+// therefore must be a multiple of `EGS=4`. +
 // Likewise, `vstart` must be a multiple of `EGS=4`.
 
 Operation::
@@ -83,7 +83,7 @@ function clause execute (VAESDM(vs2, vd, suffix)) = {
 
   eg_len = (vl/EGS)
   eg_start = (vstart/EGS)
-  
+
   foreach (i from eg_start to eg_len-1) {
     let keyelem = if suffix == "vv" then i else 0;
     let state : bits(128) = get_velem(vd, EGW=128, i);
@@ -100,4 +100,4 @@ function clause execute (VAESDM(vs2, vd, suffix)) = {
 --
 
 Included in::
-<<zvkn>>, <<zvknc>>, <<zvkned>>, <<zvkng>>, <<zvknh>>
+<<zvkn>>, <<zvknc>>, <<zvkned>>, <<zvkng>>

--- a/doc/vector/insns/vaesef.adoc
+++ b/doc/vector/insns/vaesef.adoc
@@ -99,4 +99,4 @@ function clause execute (VAESEF(vs2, vd, suffix) = {
 --
 
 Included in::
-<<zvkn>>, <<zvknc>>, <<zvkned>>, <<zvkng>>, <<zvknh>>
+<<zvkn>>, <<zvknc>>, <<zvkned>>, <<zvkng>>

--- a/doc/vector/insns/vaesem.adoc
+++ b/doc/vector/insns/vaesem.adoc
@@ -100,4 +100,4 @@ function clause execute (VAESEM(vs2, vd, suffix)) = {
 --
 
 Included in::
-<<zvkn>>, <<zvknc>>, <<zvkned>>, <<zvkng>>, <<zvknh>>
+<<zvkn>>, <<zvknc>>, <<zvkned>>, <<zvkng>>

--- a/doc/vector/insns/vaeskf1.adoc
+++ b/doc/vector/insns/vaeskf1.adoc
@@ -110,4 +110,4 @@ function clause execute (VAESKF1(rnd, vd, vs2)) = {
 --
 
 Included in::
-<<zvkn>>, <<zvknc>>, <<zvkned>>, <<zvkng>>, <<zvknh>>
+<<zvkn>>, <<zvknc>>, <<zvkned>>, <<zvkng>>

--- a/doc/vector/insns/vaeskf2.adoc
+++ b/doc/vector/insns/vaeskf2.adoc
@@ -107,4 +107,4 @@ function clause execute (VAESKF2(rnd, vd, vs2)) = {
 --
 
 Included in::
-<<zvkn>>, <<zvknc>>, <<zvkned>>, <<zvkng>>, <<zvknh>>
+<<zvkn>>, <<zvknc>>, <<zvkned>>, <<zvkng>>

--- a/doc/vector/insns/vaesz.adoc
+++ b/doc/vector/insns/vaesz.adoc
@@ -92,4 +92,4 @@ function clause execute (VAESZ(vs2, vd) = {
 --
 
 Included in::
-<<zvkn>>, <<zvknc>>, <<zvkned>>, <<zvkng>>, <<zvknh>>
+<<zvkn>>, <<zvknc>>, <<zvkned>>, <<zvkng>>


### PR DESCRIPTION
I don't think `vaes*` instructions are actually part of `Zvknh`, are they @kdockser ?