### PR TITLE
[#379][vector] instruction constraints vgh* -> vg*

### DIFF
--- a/doc/vector/riscv-crypto-vector-instruction-constraints.adoc
+++ b/doc/vector/riscv-crypto-vector-instruction-constraints.adoc
@@ -17,7 +17,7 @@ Element Group Size (`EGS`).
 
 | vaes*   | 4
 | vsha2*  | 4
-| vgh*    | 4
+| vg*     | 4
 | vsm3*   | 8 
 | vsm4*   | 4
 
@@ -37,7 +37,7 @@ _illegal instruction exception_ is raised, even if `vl`=0.
 | vaes*   | 32 | 128
 | vsha2*  | 32 | 128
 | vsha2*  | 64 | 256
-| vgh*    | 32 | 128
+| vg*     | 32 | 128
 | vsm3*   | 32 | 256 
 | vsm4*   | 32 | 128
 
@@ -58,7 +58,7 @@ all other `SEW` values are _reserved_.
 | Zvknha: vsha2* | 32
 | Zvknhb: vsha2* | 32 or 64
 | vclmul[h]      | 64
-| vgh*           | 32
+| vg*            | 32
 | vsm3*          | 32
 | vsm4*          | 32
 


### PR DESCRIPTION
Fixing typo reported by @Mingku-Chang in https://github.com/riscv/riscv-crypto/issues/379

The regular expression `vgh*` to match both `vghsh` and `vgmul` was not correct, certainly because it was not updated following a rename of the instructions during the specification process.